### PR TITLE
Refactor gaze extraction and velocity for millimetre data

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -1,15 +1,12 @@
 """Backward-compatible wrapper for the new extractor module."""
-from ivt.extractor import TobiiTSVExtractor, convert_tobii_tsv_to_ivt_tsv
+from ivt.extractor import (
+    TobiiTSVExtractor,
+    convert_tobii_tsv_to_ivt_tsv,
+    main as extractor_main,
+)
 
 __all__ = ["TobiiTSVExtractor", "convert_tobii_tsv_to_ivt_tsv"]
 
 
 if __name__ == "__main__":
-    import argparse
-
-    parser = argparse.ArgumentParser(description="Convert Tobii TSV exports to slim IVT TSV")
-    parser.add_argument("input", help="Raw Tobii TSV path")
-    parser.add_argument("output", help="Output path for slim TSV")
-    args = parser.parse_args()
-
-    convert_tobii_tsv_to_ivt_tsv(args.input, args.output)
+    extractor_main()

--- a/ivt/cli.py
+++ b/ivt/cli.py
@@ -29,6 +29,24 @@ def build_parser() -> argparse.ArgumentParser:
         default="average",
         help="Eye selection strategy",
     )
+    velocity.add_argument(
+        "--use-gaze-mm",
+        action="store_true",
+        default=True,
+        help="Use millimetre gaze columns (default)",
+    )
+    velocity.add_argument(
+        "--no-use-gaze-mm",
+        dest="use_gaze_mm",
+        action="store_false",
+        help="Use pixel gaze columns instead of millimetres",
+    )
+    velocity.add_argument(
+        "--pixel-size-mm",
+        type=float,
+        default=None,
+        help="Pixel size in millimetres (required if not using mm gaze)",
+    )
 
     classify = sub.add_parser("classify", help="Apply IVT classifier to a velocity TSV")
     classify.add_argument("input", help="TSV containing velocity_deg_per_sec")
@@ -79,7 +97,12 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if args.command == "velocity":
-        cfg = OlsenVelocityConfig(window_length_ms=args.window, eye_mode=args.eye)
+        cfg = OlsenVelocityConfig(
+            window_length_ms=args.window,
+            eye_mode=args.eye,
+            use_gaze_mm=args.use_gaze_mm,
+            pixel_size_mm=args.pixel_size_mm,
+        )
         calculator = VelocityCalculator(cfg)
         calculator.compute_from_file(args.input, args.output)
         return

--- a/ivt/combiner.py
+++ b/ivt/combiner.py
@@ -1,20 +1,120 @@
 """Gaze/eye data combination utilities."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Optional
+from typing import Tuple
 
 import pandas as pd
 
 from .config import OlsenVelocityConfig
 
 
-@dataclass
-class CombinedGaze:
-    x_px: Optional[float]
-    y_px: Optional[float]
-    eye_z_mm: Optional[float]
-    is_valid: bool
+def _to_float(value):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if cleaned == "":
+            return None
+        cleaned = cleaned.replace(",", ".")
+        try:
+            return float(cleaned)
+        except ValueError:
+            return None
+
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_validity(value: object) -> int:
+    """Parse Tobii-style validity into a numeric code.
+
+    Rules:
+    - strings:
+      - "Valid"   -> 0
+      - "Invalid" -> 999
+    - numeric strings like "0", "1", "2" -> int(value)
+    - anything else -> 999 (treat as not trustworthy)
+    """
+
+    if isinstance(value, str):
+        normalized = value.strip()
+        if normalized.lower() == "valid":
+            return 0
+        if normalized.lower() == "invalid":
+            return 999
+        try:
+            return int(normalized)
+        except ValueError:
+            return 999
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 999
+
+
+def combine_gaze_and_eye(row: pd.Series, cfg: OlsenVelocityConfig) -> Tuple[float | None, float | None, float | None, bool]:
+    """Combine left/right gaze and eye position into a single gaze point and Z distance.
+
+    Returns: (gaze_x, gaze_y, eye_z_mm, is_valid)
+    - gaze_x / gaze_y are in mm if cfg.use_gaze_mm is True,
+      otherwise in px.
+    - eye_z_mm is always in millimetres.
+    - is_valid is True if the combined gaze is trustworthy for velocity.
+    """
+
+    if cfg.use_gaze_mm:
+        lx = _to_float(row.get("gaze_left_x_mm"))
+        ly = _to_float(row.get("gaze_left_y_mm"))
+        rx = _to_float(row.get("gaze_right_x_mm"))
+        ry = _to_float(row.get("gaze_right_y_mm"))
+    else:
+        lx = _to_float(row.get("gaze_left_x_px"))
+        ly = _to_float(row.get("gaze_left_y_px"))
+        rx = _to_float(row.get("gaze_right_x_px"))
+        ry = _to_float(row.get("gaze_right_y_px"))
+
+    lz = _to_float(row.get("eye_left_z_mm"))
+    rz = _to_float(row.get("eye_right_z_mm"))
+
+    v_left = parse_validity(row.get("validity_left"))
+    v_right = parse_validity(row.get("validity_right"))
+
+    left_valid = v_left <= cfg.max_validity and lx is not None and ly is not None and not pd.isna(lx) and not pd.isna(ly)
+    right_valid = v_right <= cfg.max_validity and rx is not None and ry is not None and not pd.isna(rx) and not pd.isna(ry)
+
+    mode = cfg.eye_mode
+
+    def select_eye(x, y, z, valid) -> Tuple[float | None, float | None, float | None, bool]:
+        return (x if pd.notna(x) else None, y if pd.notna(y) else None, z if pd.notna(z) else None, valid and pd.notna(x) and pd.notna(y))
+
+    if mode == "left":
+        return select_eye(lx, ly, lz, left_valid)
+    if mode == "right":
+        return select_eye(rx, ry, rz, right_valid)
+
+    if left_valid and right_valid:
+        gaze_x = (lx + rx) / 2.0
+        gaze_y = (ly + ry) / 2.0
+        if pd.notna(lz) and pd.notna(rz):
+            eye_z = (lz + rz) / 2.0
+        elif pd.notna(lz):
+            eye_z = lz
+        elif pd.notna(rz):
+            eye_z = rz
+        else:
+            eye_z = None
+        return gaze_x, gaze_y, eye_z, True
+
+    if left_valid:
+        return select_eye(lx, ly, lz, True)
+    if right_valid:
+        return select_eye(rx, ry, rz, True)
+    return None, None, None, False
 
 
 class EyeCombiner:
@@ -23,92 +123,25 @@ class EyeCombiner:
     def __init__(self, config: OlsenVelocityConfig) -> None:
         self.config = config
 
-    @staticmethod
-    def _to_float(value):
-        if value is None:
-            return None
-        if isinstance(value, (int, float)):
-            return float(value)
-        if isinstance(value, str):
-            cleaned = value.strip()
-            if cleaned == "":
-                return None
-            cleaned = cleaned.replace(",", ".")
-            try:
-                return float(cleaned)
-            except ValueError:
-                return None
-
-        try:
-            return float(value)
-        except (TypeError, ValueError):
-            return None
-
-    @staticmethod
-    def _parse_validity(value) -> int:
-        if isinstance(value, str):
-            v = value.strip().lower()
-            if v == "valid":
-                return 0
-            if v == "invalid":
-                return 999
-
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return 999
-
-    def _combine_row(self, row: pd.Series) -> CombinedGaze:
-        cfg = self.config
-        v_left = self._parse_validity(row.get("validity_left"))
-        v_right = self._parse_validity(row.get("validity_right"))
-
-        lx = self._to_float(row.get("gaze_left_x_px"))
-        ly = self._to_float(row.get("gaze_left_y_px"))
-        rx = self._to_float(row.get("gaze_right_x_px"))
-        ry = self._to_float(row.get("gaze_right_y_px"))
-        lz = self._to_float(row.get("eye_left_z_mm"))
-        rz = self._to_float(row.get("eye_right_z_mm"))
-
-        left_valid = lx is not None and ly is not None and v_left <= cfg.max_validity
-        right_valid = rx is not None and ry is not None and v_right <= cfg.max_validity
-
-        def use_left() -> CombinedGaze:
-            return CombinedGaze(lx, ly, lz if pd.notna(lz) else None, True)
-
-        def use_right() -> CombinedGaze:
-            return CombinedGaze(rx, ry, rz if pd.notna(rz) else None, True)
-
-        mode = cfg.eye_mode
-        if mode == "left":
-            return use_left() if left_valid else CombinedGaze(None, None, None, False)
-        if mode == "right":
-            return use_right() if right_valid else CombinedGaze(None, None, None, False)
-
-        if left_valid and right_valid:
-            gaze_x = (lx + rx) / 2.0
-            gaze_y = (ly + ry) / 2.0
-            if pd.notna(lz) and pd.notna(rz):
-                eye_z = (lz + rz) / 2.0
-            elif pd.notna(lz):
-                eye_z = lz
-            elif pd.notna(rz):
-                eye_z = rz
-            else:
-                eye_z = None
-            return CombinedGaze(gaze_x, gaze_y, eye_z, True)
-
-        if left_valid:
-            return use_left()
-        if right_valid:
-            return use_right()
-        return CombinedGaze(None, None, None, False)
-
     def add_combined_columns(self, df: pd.DataFrame) -> pd.DataFrame:
-        combined = [self._combine_row(row) for _, row in df.iterrows()]
         df = df.copy()
-        df["combined_x_px"] = [c.x_px for c in combined]
-        df["combined_y_px"] = [c.y_px for c in combined]
-        df["eye_z_mm"] = [c.eye_z_mm for c in combined]
-        df["combined_valid"] = [c.is_valid for c in combined]
+        gaze_x = []
+        gaze_y = []
+        eye_z = []
+        valid = []
+        for _, row in df.iterrows():
+            gx, gy, gz, is_valid = combine_gaze_and_eye(row, self.config)
+            gaze_x.append(gx)
+            gaze_y.append(gy)
+            eye_z.append(gz)
+            valid.append(is_valid)
+
+        if self.config.use_gaze_mm:
+            df["combined_x_mm"] = gaze_x
+            df["combined_y_mm"] = gaze_y
+        else:
+            df["combined_x_px"] = gaze_x
+            df["combined_y_px"] = gaze_y
+        df["eye_z_mm"] = eye_z
+        df["combined_valid"] = valid
         return df

--- a/ivt/config.py
+++ b/ivt/config.py
@@ -1,6 +1,6 @@
 """Configuration dataclasses for IVT processing."""
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Optional
 
 
 @dataclass(frozen=True)
@@ -11,7 +11,14 @@ class OlsenVelocityConfig:
     eye_mode: Literal["left", "right", "average"] = "average"
     max_validity: int = 1
     min_dt_ms: float = 0.1
-    default_eye_distance_mm: float = 600.0
+    gap_fill: bool = False
+    max_gap_length_ms: float = 75.0
+
+    # Use mm gaze as primary representation
+    use_gaze_mm: bool = True
+
+    # Optional pixel size in mm (only needed if we ever fall back to px)
+    pixel_size_mm: Optional[float] = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_extractor_module.py
+++ b/tests/test_extractor_module.py
@@ -6,28 +6,38 @@ from ivt.extractor import RAW_COLUMNS, TobiiTSVExtractor
 def test_extractor_filters_sensor_and_maps_columns(tmp_path):
     raw = pd.DataFrame(
         {
-            "Sensor": ["Eye Tracker", "IMU"],
-            RAW_COLUMNS["time_ms"]: [0, 1],
-            RAW_COLUMNS["gaze_left_x_px"]: [1.0, 99.0],
-            RAW_COLUMNS["gaze_left_y_px"]: [2.0, 99.0],
-            RAW_COLUMNS["gaze_right_x_px"]: [3.0, 99.0],
-            RAW_COLUMNS["gaze_right_y_px"]: [4.0, 99.0],
-            RAW_COLUMNS["validity_left"]: [0, 9],
-            RAW_COLUMNS["validity_right"]: [0, 9],
-            RAW_COLUMNS["eye_left_z_mm"]: [600.0, 0.0],
-            RAW_COLUMNS["eye_right_z_mm"]: [600.0, 0.0],
+            "Sensor": ["Eye Tracker", "Eye Tracker", "IMU"],
+            RAW_COLUMNS["time_ms"]: [1, 0, 2],
+            RAW_COLUMNS["gaze_left_x_mm"]: [1.0, 99.0, 0.0],
+            RAW_COLUMNS["gaze_left_y_mm"]: [2.0, 99.0, 0.0],
+            RAW_COLUMNS["gaze_right_x_mm"]: [3.0, 99.0, 0.0],
+            RAW_COLUMNS["gaze_right_y_mm"]: [4.0, 99.0, 0.0],
+            RAW_COLUMNS["gaze_left_x_px"]: [10.0, 990.0, 0.0],
+            RAW_COLUMNS["gaze_left_y_px"]: [20.0, 990.0, 0.0],
+            RAW_COLUMNS["gaze_right_x_px"]: [30.0, 990.0, 0.0],
+            RAW_COLUMNS["gaze_right_y_px"]: [40.0, 990.0, 0.0],
+            RAW_COLUMNS["validity_left"]: ["Valid", "Invalid", "Valid"],
+            RAW_COLUMNS["validity_right"]: [0, 9, 0],
+            RAW_COLUMNS["eye_left_x_mm"]: [100.0, 0.0, 0.0],
+            RAW_COLUMNS["eye_left_y_mm"]: [200.0, 0.0, 0.0],
+            RAW_COLUMNS["eye_left_z_mm"]: [600.0, 0.0, 0.0],
+            RAW_COLUMNS["eye_right_x_mm"]: [150.0, 0.0, 0.0],
+            RAW_COLUMNS["eye_right_y_mm"]: [250.0, 0.0, 0.0],
+            RAW_COLUMNS["eye_right_z_mm"]: [650.0, 0.0, 0.0],
+            RAW_COLUMNS["gt_event_type"]: ["Fixation", "Unknown", "Saccade"],
+            RAW_COLUMNS["gt_event_index"]: [1, 2, 3],
         }
     )
 
     raw_path = tmp_path / "raw.tsv"
     output_path = tmp_path / "slim.tsv"
-    raw.to_csv(raw_path, sep="\t", index=False)
+    raw.to_csv(raw_path, sep="\t", index=False, decimal=",")
 
     extractor = TobiiTSVExtractor()
     extractor.convert(str(raw_path), str(output_path))
 
-    slim = pd.read_csv(output_path, sep="\t")
-    assert len(slim) == 1
+    slim = pd.read_csv(output_path, sep="\t", decimal=",")
+    assert list(slim.columns) == list(RAW_COLUMNS.keys())
     assert slim.loc[0, "time_ms"] == 0
-    assert "gaze_left_x_px" in slim.columns
-    assert "eye_right_z_mm" in slim.columns
+    assert slim.loc[1, "gaze_left_x_mm"] == 1.0
+    assert slim.loc[1, "gt_event_type"] == "Fixation"

--- a/tests/test_velocity_module.py
+++ b/tests/test_velocity_module.py
@@ -7,14 +7,14 @@ from ivt.config import OlsenVelocityConfig
 from ivt.velocity import VelocityCalculator
 
 
-def test_velocity_computation_uses_window_and_distance():
+def test_velocity_computation_uses_window_and_distance_mm():
     df = pd.DataFrame(
         {
             "time_ms": [0, 10, 20],
-            "gaze_left_x_px": [0.0, 1.0, 2.0],
-            "gaze_left_y_px": [0.0, 0.0, 0.0],
-            "gaze_right_x_px": [0.0, 1.0, 2.0],
-            "gaze_right_y_px": [0.0, 0.0, 0.0],
+            "gaze_left_x_mm": [0.0, 1.0, 2.0],
+            "gaze_left_y_mm": [0.0, 0.0, 0.0],
+            "gaze_right_x_mm": [0.0, 1.0, 2.0],
+            "gaze_right_y_mm": [0.0, 0.0, 0.0],
             "validity_left": [0, 0, 0],
             "validity_right": [0, 0, 0],
             "eye_left_z_mm": [600.0, 600.0, 600.0],
@@ -22,7 +22,7 @@ def test_velocity_computation_uses_window_and_distance():
         }
     )
 
-    calc = VelocityCalculator(OlsenVelocityConfig(window_length_ms=20, eye_mode="average"))
+    calc = VelocityCalculator(OlsenVelocityConfig(window_length_ms=20, eye_mode="average", use_gaze_mm=True))
     result = calc.compute(df)
 
     expected_angle = math.degrees(math.atan2(2.0, 600.0))
@@ -37,10 +37,10 @@ def test_velocity_respects_minimum_time_delta():
     df = pd.DataFrame(
         {
             "time_ms": [0, 0],
-            "gaze_left_x_px": [0.0, 1.0],
-            "gaze_left_y_px": [0.0, 0.0],
-            "gaze_right_x_px": [0.0, 1.0],
-            "gaze_right_y_px": [0.0, 0.0],
+            "gaze_left_x_mm": [0.0, 1.0],
+            "gaze_left_y_mm": [0.0, 0.0],
+            "gaze_right_x_mm": [0.0, 1.0],
+            "gaze_right_y_mm": [0.0, 0.0],
             "validity_left": [0, 0],
             "validity_right": [0, 0],
             "eye_left_z_mm": [600.0, 600.0],
@@ -57,10 +57,10 @@ def test_velocity_accepts_comma_decimal_strings():
     df = pd.DataFrame(
         {
             "time_ms": [0, 10, 20],
-            "gaze_left_x_px": ["0,0", "1,0", "2,0"],
-            "gaze_left_y_px": ["0,0", "0,0", "0,0"],
-            "gaze_right_x_px": ["0,0", "1,0", "2,0"],
-            "gaze_right_y_px": ["0,0", "0,0", "0,0"],
+            "gaze_left_x_mm": ["0,0", "1,0", "2,0"],
+            "gaze_left_y_mm": ["0,0", "0,0", "0,0"],
+            "gaze_right_x_mm": ["0,0", "1,0", "2,0"],
+            "gaze_right_y_mm": ["0,0", "0,0", "0,0"],
             "validity_left": [0, 0, 0],
             "validity_right": [0, 0, 0],
             "eye_left_z_mm": ["573,4", "573,4", "573,4"],


### PR DESCRIPTION

- update the extractor to output millimetre-based gaze data with optional pixel columns and a new CLI
- refactor velocity calculation to operate on millimetres, including validity parsing, gaze combination, and CLI options
- refresh supporting geometry/combiner utilities and tests for the new mm-focused workflow


