### PR TITLE
Fix simple_api window_utils import and add public API import smoke tests

### DIFF
--- a/ivt_filter/simple_api.py
+++ b/ivt_filter/simple_api.py
@@ -23,7 +23,7 @@ from typing import Optional, Literal
 import pandas as pd
 
 from .io.pipeline import IVTPipeline
-from .window_utils import create_time_based_config, create_adaptive_config
+from .utils.window_utils import create_time_based_config, create_adaptive_config
 from .io.io import read_tsv
 
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,25 @@
+"""Smoke tests for the public simple API imports."""
+
+
+def test_import_process_eye_tracking() -> None:
+    from ivt_filter.simple_api import process_eye_tracking
+
+    assert callable(process_eye_tracking)
+
+
+def test_import_process_eye_tracking_adaptive() -> None:
+    from ivt_filter.simple_api import process_eye_tracking_adaptive
+
+    assert callable(process_eye_tracking_adaptive)
+
+
+def test_import_get_statistics() -> None:
+    from ivt_filter.simple_api import get_statistics
+
+    assert callable(get_statistics)
+
+
+def test_import_print_statistics() -> None:
+    from ivt_filter.simple_api import print_statistics
+
+    assert callable(print_statistics)


### PR DESCRIPTION
### Motivation
- Behebt einen fehlerhaften relativen Import in `ivt_filter/simple_api.py` und stellt sicher, dass die Simple-API den kanonischen Modulpfad verwendet.
- Vermeidet das Hinzufügen eines unnötigen Root-Kompatibilitäts-Shims, da kein `ivt_filter/window_utils.py` und keine Historie eines solchen Root-Moduls gefunden wurde.
- Stellt durch Import-Smoke-Tests sicher, dass die öffentlich dokumentierten Hilfsfunktionen beim Import verfügbar sind.

### Description
- Ersetzt den Import `from .window_utils import ...` in `ivt_filter/simple_api.py` durch `from .utils.window_utils import create_time_based_config, create_adaptive_config`.
- Fügt neue Import-only Smoke-Tests in `tests/test_public_api.py` hinzu, die `process_eye_tracking`, `process_eye_tracking_adaptive`, `get_statistics` und `print_statistics` importieren und prüfen, dass sie aufrufbar sind.
- Kein Rückwärtskompatibilitätsmodul `ivt_filter/window_utils.py` wurde erstellt, weil der kanonische Pfad `ivt_filter.utils.window_utils` als alleinige Implementierung vorliegt.

### Testing
- `pytest tests/test_public_api.py -q` wurde ausgeführt und die 4 neuen Tests bestanden.
- Die vollständige Test-Suite wurde mit `pytest -q` ausgeführt und lieferte `126 passed, 1 skipped`.
- Die Änderungen liefen lokal durch die Testläufe ohne Fehler.

