### PR TITLE
Refactor Olsen velocity processing into testable pipeline components

### DIFF
--- a/ivt_filter/processing/velocity.py
+++ b/ivt_filter/processing/velocity.py
@@ -36,7 +36,10 @@ from ..strategies import (
     Ray3DGazeDir,
     TobiiGazeDirAngle,
 )
-from ..strategies.window_rounding import StandardWindowRounding, SymmetricRoundWindowStrategy
+from ..strategies.window_rounding import (
+    StandardWindowRounding,
+    SymmetricRoundWindowStrategy,
+)
 from ..strategies.coordinate_rounding import (
     NoRounding,
     RoundToNearest,
@@ -44,7 +47,6 @@ from ..strategies.coordinate_rounding import (
     FloorRounding,
     CeilRounding,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -71,7 +73,7 @@ def visual_angle_deg(
     eye_z_mm: Optional[float],
 ) -> float:
     """Calculate visual angle between two points.
-    
+
     Legacy wrapper using Olsen 2D approximation.
     """
     dx = float(x2_mm) - float(x1_mm)
@@ -112,31 +114,37 @@ def make_window_selector(cfg: OlsenVelocityConfig) -> WindowSelector:
     # Asymmetrisches Nachbar-Fenster (2 Samples)
     if cfg.asymmetric_neighbor_window:
         return AsymmetricNeighborWindowSelector()
-    
+
     # Select strategy
     rounding_strategy: WindowRoundingStrategy
     if cfg.symmetric_round_window:
         rounding_strategy = SymmetricRoundWindowStrategy()
     else:
         rounding_strategy = StandardWindowRounding()
-    
+
     if cfg.shifted_valid_window:
         if cfg.fixed_window_samples is not None:
             # Sample-based shifted valid window
             n = int(cfg.fixed_window_samples)
             if n < 3:
-                raise ValueError("fixed_window_samples must be >= 3 for shifted_valid_window.")
+                raise ValueError(
+                    "fixed_window_samples must be >= 3 for shifted_valid_window."
+                )
             half_size = rounding_strategy.calculate_half_size(n)
-            return ShiftedValidWindowSelector(half_size=half_size, fallback_mode=cfg.shifted_valid_fallback)
+            return ShiftedValidWindowSelector(
+                half_size=half_size, fallback_mode=cfg.shifted_valid_fallback
+            )
         else:
             # Time-based shifted valid window
-            return TimeBasedShiftedValidWindowSelector(fallback_mode=cfg.shifted_valid_fallback)
+            return TimeBasedShiftedValidWindowSelector(
+                fallback_mode=cfg.shifted_valid_fallback
+            )
 
     if cfg.fixed_window_samples is not None:
         n = int(cfg.fixed_window_samples)
         if n < 3:
             raise ValueError("fixed_window_samples must be >= 3.")
-        
+
         half_size = rounding_strategy.calculate_half_size(n)
         return FixedSampleSymmetricWindowSelector(half_size=half_size)
 
@@ -172,7 +180,7 @@ def _calculate_dt_ms(
 ) -> float:
     """
     Berechne Zeitdifferenz dt_ms basierend auf Fenster-Selector-Typ.
-    
+
     - AsymmetricNeighbor: nutze fixed dt aus Sampling-Rate
     - FixedSampleSymmetric: nutze nominalen dt (ohne Timestamp-Jitter)
     - ShiftedValid: nutze tatsächliche Zeitstempel-Differenzen
@@ -183,7 +191,7 @@ def _calculate_dt_ms(
             return 1000.0 / hz_measured
         else:
             return float(times[last_idx]) - float(times[first_idx])
-    
+
     if isinstance(selector, FixedSampleSymmetricWindowSelector):
         if hz_measured is not None and hz_measured > 0:
             window_size = last_idx - first_idx + 1
@@ -191,10 +199,10 @@ def _calculate_dt_ms(
             return window_spans * (1000.0 / hz_measured)
         else:
             return float(times[last_idx]) - float(times[first_idx])
-    
+
     if isinstance(selector, ShiftedValidWindowSelector):
         return float(times[last_idx]) - float(times[first_idx])
-    
+
     # Default: normale dt-Berechnung
     return float(times[last_idx]) - float(times[first_idx])
 
@@ -217,7 +225,7 @@ def _get_direction_vectors(
 ) -> tuple:
     """
     Extrahiere Richtungsvektoren für beide Endpunkte.
-    
+
     Rückgabe: (dir_first_tuple, dir_last_tuple)
     """
     if eye_consistent_override and used_eye == "left":
@@ -244,7 +252,7 @@ def _get_direction_vectors(
             combined_dir_y[last_idx],
             combined_dir_z[last_idx],
         )
-    
+
     return dir_first, dir_last
 
 
@@ -263,9 +271,9 @@ def _apply_eye_consistent_override(
 ) -> tuple:
     """
     Wende Eye-Consistent-Override für Ray3DGazeDir an (3-sample window).
-    
+
     Wählt ein Auge, das an beiden Endpunkten gültig ist, oder überspringt Velocity.
-    
+
     Rückgabe: (x1, y1, x2, y2, used_eye, override_applied, should_skip)
     - should_skip: True wenn keine konsistente Augen-Wahl möglich
     """
@@ -275,10 +283,10 @@ def _apply_eye_consistent_override(
         and (last_idx - first_idx) == 2
     ):
         return None, None, None, None, eye_mode, False, False
-    
+
     left_both_valid = bool(left_valid[first_idx]) and bool(left_valid[last_idx])
     right_both_valid = bool(right_valid[first_idx]) and bool(right_valid[last_idx])
-    
+
     if left_both_valid:
         x1, y1 = lx[first_idx], ly[first_idx]
         x2, y2 = lx[last_idx], ly[last_idx]
@@ -292,36 +300,284 @@ def _apply_eye_consistent_override(
         return None, None, None, None, eye_mode, False, True
 
 
-def compute_olsen_velocity(
+@dataclasses.dataclass(frozen=True)
+class VelocityInputArrays:
+    """NumPy views used while computing velocity samples."""
+
+    times: np.ndarray
+    combined_x: np.ndarray
+    combined_y: np.ndarray
+    left_valid: np.ndarray
+    right_valid: np.ndarray
+    valid: np.ndarray
+    left_x: np.ndarray
+    left_y: np.ndarray
+    right_x: np.ndarray
+    right_y: np.ndarray
+
+    @classmethod
+    def from_dataframe(
+        cls, df: pd.DataFrame, valid: Optional[np.ndarray] = None
+    ) -> "VelocityInputArrays":
+        left_valid = df["left_eye_valid"].to_numpy()
+        right_valid = df["right_eye_valid"].to_numpy()
+        if valid is None:
+            valid = df["combined_valid"].to_numpy()
+        return cls(
+            times=df["time_ms"].to_numpy(),
+            combined_x=df["smoothed_x_mm"].to_numpy(),
+            combined_y=df["smoothed_y_mm"].to_numpy(),
+            left_valid=left_valid,
+            right_valid=right_valid,
+            valid=valid,
+            left_x=df["gaze_left_x_mm"].to_numpy(),
+            left_y=df["gaze_left_y_mm"].to_numpy(),
+            right_x=df["gaze_right_x_mm"].to_numpy(),
+            right_y=df["gaze_right_y_mm"].to_numpy(),
+        )
+
+
+@dataclasses.dataclass(frozen=True)
+class VelocityComputationResult:
+    """Structured result of sampling analysis, including the effective config."""
+
+    dt_ms: Optional[float]
+    hz_measured: Optional[float]
+    config: OlsenVelocityConfig
+
+
+class SamplingAnalyzer:
+    """Analyze timestamp spacing and derive an optional fixed sample window."""
+
+    NOMINAL_RATES = (30.0, 50.0, 60.0, 120.0, 150.0, 250.0, 300.0, 500.0, 600.0, 1000.0)
+
+    def analyze(
+        self, times: np.ndarray, cfg: OlsenVelocityConfig
+    ) -> VelocityComputationResult:
+        if len(times) < 2:
+            return VelocityComputationResult(None, None, cfg)
+        if cfg.sampling_rate_method == "first_100":
+            sample_count = min(100, len(times) - 1)
+            deltas = np.diff(times[: sample_count + 1])
+            method_desc = f"first {sample_count} samples"
+        else:
+            deltas = np.diff(times)
+            method_desc = "all samples"
+        deltas = deltas[np.isfinite(deltas)]
+        if deltas.size == 0:
+            return VelocityComputationResult(None, None, cfg)
+        dt_ms = float(
+            np.median(deltas)
+            if cfg.dt_calculation_method == "median"
+            else np.mean(deltas)
+        )
+        hz_measured = 1000.0 / dt_ms if dt_ms > 0 else float("nan")
+        print(
+            f"[Sampling] {cfg.dt_calculation_method} dt = {dt_ms:.3f} ms -> measured ~{hz_measured:.1f} Hz (using {method_desc})"
+        )
+        if math.isfinite(hz_measured):
+            nearest = min(self.NOMINAL_RATES, key=lambda rate: abs(rate - hz_measured))
+            print(f"[Sampling] nearest nominal rate: {nearest:.1f} Hz")
+        should_convert = cfg.auto_fixed_window_from_ms or cfg.symmetric_round_window
+        if should_convert and cfg.fixed_window_samples is None and dt_ms > 0:
+            intervals = max(1, int(round(cfg.window_length_ms / dt_ms)))
+            samples = max(3, intervals + 1)
+            if samples % 2 == 0:
+                samples += 1
+            effective_ms = (samples - 1) * dt_ms
+            cfg = dataclasses.replace(cfg, fixed_window_samples=samples)
+            print(
+                f"[Window] auto sample window: {samples} samples total (~{(samples - 1) / 2.0:.1f} pro Seite um das Zentrum, effektive Spannweite ~{effective_ms:.2f} ms)"
+            )
+        return VelocityComputationResult(dt_ms, hz_measured, cfg)
+
+
+class VelocityStrategyFactory:
+    """Create visual-angle calculation strategies from configuration values."""
+
+    @staticmethod
+    def create(method: str) -> VelocityCalculationStrategy:
+        return _get_velocity_calculation_strategy(method)
+
+
+class WindowSelectorFactory:
+    """Create velocity-window selectors from a velocity configuration."""
+
+    @staticmethod
+    def create(cfg: OlsenVelocityConfig) -> WindowSelector:
+        return make_window_selector(cfg)
+
+
+def normalize_timestamps(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataFrame:
+    """Copy, normalize and sort the configured timestamp column to milliseconds."""
+    result = df.copy()
+    time_col = getattr(cfg, "time_column", "time_ms")
+    time_unit = getattr(cfg, "time_unit", "ms")
+    if time_col not in result.columns:
+        raise ValueError(f"DataFrame must contain '{time_col}' column")
+    divisor = {"ms": 1.0, "us": 1000.0, "ns": 1_000_000.0}.get(time_unit, 1.0)
+    result["time_ms"] = result[time_col].astype(float) / divisor
+    return result.sort_values("time_ms").reset_index(drop=True)
+
+
+def prepare_velocity_input(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataFrame:
+    """Run gaze preprocessing required before velocity sample computation."""
+    result = gap_fill_gaze(df, cfg)
+    if getattr(cfg, "tobii_eye_offset_interpolation", False):
+        result = apply_tobii_eye_offset_interpolation(result, cfg)
+    result = prepare_combined_columns(result, cfg)
+    return smooth_combined_gaze(result, cfg)
+
+
+def find_single_eye_endpoints(
+    valid: np.ndarray, first_idx: int, last_idx: int
+) -> tuple[Optional[int], Optional[int]]:
+    """Return the first and last valid endpoint for one eye inside a window."""
+    first = next((idx for idx in range(first_idx, last_idx + 1) if valid[idx]), None)
+    last = next((idx for idx in range(last_idx, first_idx - 1, -1) if valid[idx]), None)
+    return first, last
+
+
+@dataclasses.dataclass(frozen=True)
+class AverageNeighborImputer:
+    """Impute a missing-eye endpoint from the closest valid neighbor in a window."""
+
+    arrays: VelocityInputArrays
+
+    @classmethod
+    def from_arrays(cls, arrays: VelocityInputArrays) -> "AverageNeighborImputer":
+        return cls(arrays)
+
+    def impute(self, idx: int, first_idx: int, last_idx: int) -> tuple[float, float]:
+        a = self.arrays
+        left_valid, right_valid = bool(a.left_valid[idx]), bool(a.right_valid[idx])
+        if left_valid == right_valid:
+            return a.combined_x[idx], a.combined_y[idx]
+        missing_right = left_valid and not right_valid
+        candidates = range(first_idx, last_idx + 1)
+        neighbor = min(
+            (
+                j
+                for j in candidates
+                if j != idx
+                and bool(a.right_valid[j] if missing_right else a.left_valid[j])
+            ),
+            key=lambda j: abs(float(a.times[j]) - float(a.times[idx])),
+            default=None,
+        )
+        if neighbor is None:
+            return a.combined_x[idx], a.combined_y[idx]
+        if missing_right:
+            values = (
+                a.left_x[idx],
+                a.left_y[idx],
+                a.right_x[neighbor],
+                a.right_y[neighbor],
+            )
+        else:
+            values = (
+                a.left_x[neighbor],
+                a.left_y[neighbor],
+                a.right_x[idx],
+                a.right_y[idx],
+            )
+        if any(pd.isna(value) for value in values):
+            return a.combined_x[idx], a.combined_y[idx]
+        return (float(values[0]) + float(values[2])) / 2.0, (
+            float(values[1]) + float(values[3])
+        ) / 2.0
+
+
+@dataclasses.dataclass(frozen=True)
+class FixedWindowEdgeFallbackContext:
+    cfg: OlsenVelocityConfig
+    selector: WindowSelector
+    valid: np.ndarray
+
+
+def apply_fixed_window_edge_fallback(
+    df: pd.DataFrame, context: FixedWindowEdgeFallbackContext
+) -> int:
+    """Copy a nearby velocity into fixed-window samples blocked by invalid edges."""
+    if not context.cfg.fixed_window_edge_fallback or not isinstance(
+        context.selector, FixedSampleSymmetricWindowSelector
+    ):
+        return 0
+    logger.info("Applying fixed_window_edge_fallback strategy...")
+    valid, half_size, count = context.valid, context.selector.half_size, 0
+    for i in range(len(df)):
+        if not bool(valid[i]) or not pd.isna(df.at[i, "velocity_deg_per_sec"]):
+            continue
+        if "gap_rule_triggered" in df.columns and bool(df.at[i, "gap_rule_triggered"]):
+            continue
+        start, end = max(0, i - half_size), min(len(df) - 1, i + half_size)
+        if not (
+            (start < i and not bool(valid[start])) or (end > i and not bool(valid[end]))
+        ):
+            continue
+        found = None
+        for offset in range(1, min(50, len(df))):
+            for candidate in (i + offset, i - offset):
+                if 0 <= candidate < len(df) and bool(valid[candidate]):
+                    velocity = df.at[candidate, "velocity_deg_per_sec"]
+                    if not pd.isna(velocity):
+                        found = velocity
+                        break
+            if found is not None:
+                break
+        if found is not None:
+            df.at[i, "velocity_deg_per_sec"] = found
+            count += 1
+    if count:
+        logger.info("Applied fallback velocity to %s samples", count)
+    return count
+
+
+@dataclasses.dataclass(frozen=True)
+class ComputedVelocitySample:
+    """Result values written for one successfully computed sample."""
+
+    velocity_deg_per_sec: float
+    raw_velocity_deg_per_sec: float
+    dt_ms: float
+
+
+class VelocitySampleComputer:
+    """Compute individual velocity values and coordinate the sample iteration."""
+
+    def __init__(self, cfg: OlsenVelocityConfig):
+        self.cfg = cfg
+
+    @staticmethod
+    def compute_sample(
+        context: VelocityContext,
+        dt_ms: float,
+        strategy: VelocityCalculationStrategy,
+    ) -> ComputedVelocitySample:
+        """Calculate one rounded velocity sample from an explicit context."""
+        angle_deg = strategy.calculate_visual_angle_ctx(context)
+        raw_velocity = angle_deg / (dt_ms / 1000.0) if dt_ms > 0 else float("nan")
+        if pd.isna(raw_velocity):
+            velocity = raw_velocity
+        else:
+            velocity = float(
+                Decimal(raw_velocity).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+            )
+        return ComputedVelocitySample(velocity, raw_velocity, dt_ms)
+
+    def compute(self, prepared_df: pd.DataFrame) -> pd.DataFrame:
+        return _compute_olsen_velocity_impl(prepared_df, self.cfg)
+
+
+def _compute_olsen_velocity_impl(
     df: pd.DataFrame,
     cfg: OlsenVelocityConfig,
 ) -> pd.DataFrame:
     """
     Olsen-Style Geschwindigkeit berechnen (mm basierte Gaze Daten).
     """
-    df = df.copy()
-
-    # Normalize time column to milliseconds (allows micro/nano inputs)
-    time_col = getattr(cfg, "time_column", "time_ms")
-    time_unit = getattr(cfg, "time_unit", "ms")
-    if time_col not in df.columns:
-        raise ValueError(f"DataFrame must contain '{time_col}' column")
-
-    unit_divisor = {"ms": 1.0, "us": 1000.0, "ns": 1_000_000.0}.get(time_unit, 1.0)
-    df["time_ms"] = df[time_col].astype(float) / unit_divisor
-
-    df = df.sort_values("time_ms").reset_index(drop=True)
-
-    # NEU: Gap Filling vor der Augen-Kombination
-    df = gap_fill_gaze(df, cfg)
-
-    # Tobii-exakte Auge-Offset-Interpolation (optional)
-    if getattr(cfg, "tobii_eye_offset_interpolation", False):
-        df = apply_tobii_eye_offset_interpolation(df, cfg)
-
-    df = prepare_combined_columns(df, cfg)
-    df = smooth_combined_gaze(df, cfg)
-
+    # Input normalization and preprocessing are coordinated by the public facade.
+    # Keep the implementation focused on sample computation.
     df = df.copy()
     df["velocity_deg_per_sec"] = float("nan")
     df["dt_ms"] = float("nan")  # Time difference used for velocity calculation
@@ -357,6 +613,7 @@ def compute_olsen_velocity(
     ly = df["gaze_left_y_mm"].to_numpy()
     rx = df["gaze_right_x_mm"].to_numpy()
     ry = df["gaze_right_y_mm"].to_numpy()
+    arrays = VelocityInputArrays.from_dataframe(df, valid=valid)
 
     # Optional: Blickrichtungs-Vektoren (DACS norm)
     ldx = df.get("gaze_dir_left_x", pd.Series([np.nan] * len(df))).to_numpy()
@@ -387,67 +644,22 @@ def compute_olsen_velocity(
             combined_dir_z[i] = rdz[i]
 
     n = len(df)
-    half_window = cfg.window_length_ms / 2.0
-    selector = make_window_selector(cfg)
 
-    # Sampling-Analyse (median dt, effektive Hz)
-    dt_med = None
-    hz_measured = None
-    if n >= 2:
-        if cfg.sampling_rate_method == "first_100":
-            # Tobii-Paper Methode: nur erste 100 Samples verwenden
-            n_samples_for_rate = min(100, n - 1)  # max 100, aber nicht mehr als verfügbar
-            dt = np.diff(times[:n_samples_for_rate + 1])
-            method_desc = f"first {n_samples_for_rate} samples"
-        else:
-            # Standard: alle Samples verwenden
-            dt = np.diff(times)
-            method_desc = "all samples"
-        
-        dt = dt[np.isfinite(dt)]
-        if dt.size > 0:
-            if cfg.dt_calculation_method == "median":
-                dt_med = float(np.median(dt))
-            else:  # mean
-                dt_med = float(np.mean(dt))
-            hz_measured = 1000.0 / dt_med if dt_med > 0 else float("nan")
-            method_name = "median" if cfg.dt_calculation_method == "median" else "mean"
-            print(f"[Sampling] {method_name} dt = {dt_med:.3f} ms -> measured ~{hz_measured:.1f} Hz (using {method_desc})")
-            if math.isfinite(hz_measured):
-                nominal_candidates = [30.0, 50.0, 60.0, 120.0, 150.0, 250.0, 300.0, 500.0, 600.0, 1000.0]
-                nearest_nom = min(nominal_candidates, key=lambda f: abs(f - hz_measured))
-                print(f"[Sampling] nearest nominal rate: {nearest_nom:.1f} Hz")
-
-            # Auto-Konvertierung ms -> Sample-Fenster, falls gewuenscht
-            # ODER wenn symmetric_round_window gesetzt ist (impliziert Sample-Fenster)
-            should_auto_convert = (cfg.auto_fixed_window_from_ms or cfg.symmetric_round_window)
-            if should_auto_convert and cfg.fixed_window_samples is None and dt_med > 0:
-                n_intervals = max(1, int(round(cfg.window_length_ms / dt_med)))
-                n_samples = n_intervals + 1
-                if n_samples < 3:
-                    n_samples = 3
-                if n_samples % 2 == 0:
-                    n_samples += 1
-                effective_ms = (n_samples - 1) * dt_med
-                per_side = (n_samples - 1) / 2.0
-                cfg = dataclasses.replace(cfg, fixed_window_samples=n_samples)
-                print(
-                    f"[Window] auto sample window: {n_samples} samples total "
-                    f"(~{per_side:.1f} pro Seite um das Zentrum, "
-                    f"effektive Spannweite ~{effective_ms:.2f} ms)"
-                )
+    # Sampling analysis can adjust the effective fixed-window configuration.
+    sampling = SamplingAnalyzer().analyze(times, cfg)
+    dt_med, hz_measured, cfg = sampling.dt_ms, sampling.hz_measured, sampling.config
 
     half_window = cfg.window_length_ms / 2.0
-    selector = make_window_selector(cfg)
+    selector = WindowSelectorFactory.create(cfg)
     logger.debug("Window selector: %s", type(selector).__name__)
-    
+
     # Koordinaten-Rounding-Strategie
     coord_rounding = _get_coordinate_rounding_strategy(cfg.coordinate_rounding)
     if cfg.coordinate_rounding != "none":
         logger.info("Coordinate rounding enabled: %s", coord_rounding.get_description())
-    
+
     # Velocity-Calculation-Strategie
-    velocity_strategy = _get_velocity_calculation_strategy(cfg.velocity_method)
+    velocity_strategy = VelocityStrategyFactory.create(cfg.velocity_method)
     if cfg.velocity_method != "olsen2d":
         logger.info("Velocity calculation method: %s", cfg.velocity_method)
 
@@ -460,7 +672,11 @@ def compute_olsen_velocity(
         # Bei Asymmetrischem Nachbar-Fenster: 2 Samples
         logger.info("Asymmetric neighbor window: 2 samples (backward/forward)")
         if cfg.use_fixed_dt and hz_measured is not None:
-            logger.info("Using fixed dt: %.4f ms (from %.1f Hz)", 1000.0 / hz_measured, hz_measured)
+            logger.info(
+                "Using fixed dt: %.4f ms (from %.1f Hz)",
+                1000.0 / hz_measured,
+                hz_measured,
+            )
     else:
         # Bei Zeit-basierten Fenstern: Schätzung basierend auf dt_med
         if dt_med is not None and dt_med > 0:
@@ -480,7 +696,9 @@ def compute_olsen_velocity(
     # Fallback: wenn der Selector sample-symmetrisch ist und kein gueltiges Fenster findet,
     # kann auf ein Zeitfenster zurueckgefallen werden.
     fallback_selector: Optional[WindowSelector] = None
-    if isinstance(selector, (SampleSymmetricWindowSelector, FixedSampleSymmetricWindowSelector)):
+    if isinstance(
+        selector, (SampleSymmetricWindowSelector, FixedSampleSymmetricWindowSelector)
+    ):
         fallback_selector = TimeSymmetricWindowSelector()
 
     # Abstand-basierte Unclassified-Regel vorbereiten
@@ -491,7 +709,10 @@ def compute_olsen_velocity(
     if isinstance(selector, AsymmetricNeighborWindowSelector):
         # 2-Sample Fenster: radius = 1
         gap_max = 1
-    elif isinstance(selector, FixedSampleSymmetricWindowSelector) and cfg.fixed_window_samples is not None:
+    elif (
+        isinstance(selector, FixedSampleSymmetricWindowSelector)
+        and cfg.fixed_window_samples is not None
+    ):
         # Ursprüngliche Fenstergröße ohne Asymmetrie-Anpassung
         original_window_size = int(cfg.fixed_window_samples)
         gap_max = max(0, original_window_size - 1)
@@ -516,48 +737,7 @@ def compute_olsen_velocity(
             next_inv = ii
         next_invalid_idx[ii] = next_inv
 
-    def impute_avg_with_neighbor(idx: int, first_idx: int, last_idx: int):
-        lv = left_valid[idx]
-        rv = right_valid[idx]
-        if (lv and rv) or (not lv and not rv):
-            return cx[idx], cy[idx]
-
-        missing_eye = "right" if lv and not rv else "left"
-        t_idx = float(times[idx])
-        best_j: Optional[int] = None
-        best_dt: Optional[float] = None
-
-        for j in range(first_idx, last_idx + 1):
-            if j == idx:
-                continue
-            if missing_eye == "right":
-                if not right_valid[j]:
-                    continue
-            else:
-                if not left_valid[j]:
-                    continue
-
-            dt_j = abs(float(times[j]) - t_idx)
-            if best_dt is None or dt_j < best_dt:
-                best_dt = dt_j
-                best_j = j
-
-        if best_j is None:
-            return cx[idx], cy[idx]
-
-        if missing_eye == "right":
-            lx_idx, ly_idx = lx[idx], ly[idx]
-            rx_idx, ry_idx = rx[best_j], ry[best_j]
-        else:
-            lx_idx, ly_idx = lx[best_j], ly[best_j]
-            rx_idx, ry_idx = rx[idx], ry[idx]
-
-        if any(pd.isna(v) for v in (lx_idx, ly_idx, rx_idx, ry_idx)):
-            return cx[idx], cy[idx]
-
-        x = (float(lx_idx) + float(rx_idx)) / 2.0
-        y = (float(ly_idx) + float(ry_idx)) / 2.0
-        return x, y
+    neighbor_imputer = AverageNeighborImputer.from_arrays(arrays)
 
     for i in range(n):
         # Explizit prüfen: nur wenn das Sample selbst gültig ist, berechne Velocity
@@ -569,9 +749,17 @@ def compute_olsen_velocity(
 
         # 2. Fallback: wenn kein sinnvolles Fenster gefunden wurde,
         #    versuche noch das klassische Zeitfenster
-        if (first_idx is None or last_idx is None or first_idx == last_idx) and fallback_selector is not None:
-            first_idx_fb, last_idx_fb = fallback_selector.select(i, times, valid, half_window)
-            if first_idx_fb is not None and last_idx_fb is not None and first_idx_fb != last_idx_fb:
+        if (
+            first_idx is None or last_idx is None or first_idx == last_idx
+        ) and fallback_selector is not None:
+            first_idx_fb, last_idx_fb = fallback_selector.select(
+                i, times, valid, half_window
+            )
+            if (
+                first_idx_fb is not None
+                and last_idx_fb is not None
+                and first_idx_fb != last_idx_fb
+            ):
                 first_idx, last_idx = first_idx_fb, last_idx_fb
 
         # Wenn immer noch kein Fenster: Velocity bleibt NaN -> Sample bleibt Unclassified
@@ -608,7 +796,7 @@ def compute_olsen_velocity(
                         break
                 else:
                     continue  # Kein gültiges Sample gefunden
-            
+
             if not valid[last_idx]:
                 # Finde nächstes gültiges Sample vor last_idx
                 for j in range(last_idx - 1, first_idx - 1, -1):
@@ -622,40 +810,62 @@ def compute_olsen_velocity(
         eye_consistent_override = False
 
         # Diagnose: Validität im aktuell gewählten Fenster
-        window_lv = left_valid[first_idx:last_idx + 1]
-        window_rv = right_valid[first_idx:last_idx + 1]
+        window_lv = left_valid[first_idx : last_idx + 1]
+        window_rv = right_valid[first_idx : last_idx + 1]
         window_any_invalid = (~window_lv | ~window_rv).any()
         df.at[i, "window_any_invalid"] = bool(window_any_invalid)
 
         # Berechne Zeitdifferenz (nutzt Window-Selector-Typ)
-        dt_ms = _calculate_dt_ms(first_idx, last_idx, times, selector, hz_measured, cfg.use_fixed_dt)
-        
+        dt_ms = _calculate_dt_ms(
+            first_idx, last_idx, times, selector, hz_measured, cfg.use_fixed_dt
+        )
+
         # Track the actual endpoints used for velocity and direction lookup
         actual_first_idx = first_idx
         actual_last_idx = last_idx
 
         # Eye-consistent override for gaze-dir velocities (3-sample symmetric window)
         override_result = _apply_eye_consistent_override(
-            velocity_strategy, cfg.eye_mode, first_idx, last_idx, times,
-            left_valid, right_valid, lx, ly, rx, ry
+            velocity_strategy,
+            cfg.eye_mode,
+            first_idx,
+            last_idx,
+            times,
+            left_valid,
+            right_valid,
+            lx,
+            ly,
+            rx,
+            ry,
         )
         x1, y1, x2, y2, chosen_eye, override_applied, should_skip = override_result
-        
+
         if should_skip:
             # No single eye valid at both endpoints -> velocity missing
             continue
-        
+
         if override_applied:
             eye_consistent_override = True
             used_eye = chosen_eye
             # dt from the chosen endpoints' timestamps (time_ms array already normalized)
-            dt_ms = _calculate_dt_ms(actual_first_idx, actual_last_idx, times, selector, hz_measured, cfg.use_fixed_dt)
+            dt_ms = _calculate_dt_ms(
+                actual_first_idx,
+                actual_last_idx,
+                times,
+                selector,
+                hz_measured,
+                cfg.use_fixed_dt,
+            )
         else:
             x1, y1 = cx[first_idx], cy[first_idx]
             x2, y2 = cx[last_idx], cy[last_idx]
 
         # Speichere finalen dt und wende min_dt-Prüfung an (außer beim späteren Single-Eye-Fallback)
-        skip_dt_check = cfg.eye_mode == "average" and cfg.average_fallback_single_eye and not eye_consistent_override
+        skip_dt_check = (
+            cfg.eye_mode == "average"
+            and cfg.average_fallback_single_eye
+            and not eye_consistent_override
+        )
         if not skip_dt_check:
             if dt_ms < cfg.min_dt_ms:
                 continue
@@ -671,8 +881,8 @@ def compute_olsen_velocity(
 
             # NEW: average_fallback_single_eye - use only valid eyes for velocity when any invalids are present
             if use_fallback_single:
-                window_lv = left_valid[first_idx:last_idx + 1]
-                window_rv = right_valid[first_idx:last_idx + 1]
+                window_lv = left_valid[first_idx : last_idx + 1]
+                window_rv = right_valid[first_idx : last_idx + 1]
                 single_valid = window_lv ^ window_rv
                 window_any_invalid = (~window_lv | ~window_rv).any()
 
@@ -680,7 +890,9 @@ def compute_olsen_velocity(
                 mid_idx = i
                 mid_left_valid = left_valid[mid_idx]
                 mid_right_valid = right_valid[mid_idx]
-                mid_mixed = (mid_left_valid and not mid_right_valid) or (not mid_left_valid and mid_right_valid)
+                mid_mixed = (mid_left_valid and not mid_right_valid) or (
+                    not mid_left_valid and mid_right_valid
+                )
 
                 # Trigger fallback whenever the window is not fully valid for both eyes
                 if window_any_invalid or single_valid.any() or mid_mixed:
@@ -688,23 +900,22 @@ def compute_olsen_velocity(
                     left_count = int(window_lv.sum())
                     right_count = int(window_rv.sum())
 
-                    def _endpoints(valid_arr):
-                        first = None
-                        last = None
-                        for j in range(first_idx, last_idx + 1):
-                            if valid_arr[j]:
-                                first = j
-                                break
-                        for j in range(last_idx, first_idx - 1, -1):
-                            if valid_arr[j]:
-                                last = j
-                                break
-                        return first, last
-
-                    left_first, left_last = _endpoints(left_valid)
-                    right_first, right_last = _endpoints(right_valid)
-                    left_span = (left_last - left_first) if left_first is not None and left_last is not None else -1
-                    right_span = (right_last - right_first) if right_first is not None and right_last is not None else -1
+                    left_first, left_last = find_single_eye_endpoints(
+                        left_valid, first_idx, last_idx
+                    )
+                    right_first, right_last = find_single_eye_endpoints(
+                        right_valid, first_idx, last_idx
+                    )
+                    left_span = (
+                        (left_last - left_first)
+                        if left_first is not None and left_last is not None
+                        else -1
+                    )
+                    right_span = (
+                        (right_last - right_first)
+                        if right_first is not None and right_last is not None
+                        else -1
+                    )
 
                     if mid_left_valid and not mid_right_valid:
                         left_count += 1
@@ -714,7 +925,9 @@ def compute_olsen_velocity(
                     score_left = (left_span, left_count)
                     score_right = (right_span, right_count)
                     if score_left == score_right:
-                        chosen_eye = "left" if mid_left_valid or not mid_right_valid else "right"
+                        chosen_eye = (
+                            "left" if mid_left_valid or not mid_right_valid else "right"
+                        )
                     else:
                         chosen_eye = "left" if score_left > score_right else "right"
 
@@ -725,7 +938,11 @@ def compute_olsen_velocity(
                         if left_last is not None:
                             actual_last_idx = left_last
 
-                        if left_first is None or left_last is None or actual_first_idx >= actual_last_idx:
+                        if (
+                            left_first is None
+                            or left_last is None
+                            or actual_first_idx >= actual_last_idx
+                        ):
                             continue
 
                         x1, y1 = lx[actual_first_idx], ly[actual_first_idx]
@@ -738,7 +955,11 @@ def compute_olsen_velocity(
                         if right_last is not None:
                             actual_last_idx = right_last
 
-                        if right_first is None or right_last is None or actual_first_idx >= actual_last_idx:
+                        if (
+                            right_first is None
+                            or right_last is None
+                            or actual_first_idx >= actual_last_idx
+                        ):
                             continue
 
                         x1, y1 = rx[actual_first_idx], ry[actual_first_idx]
@@ -746,14 +967,20 @@ def compute_olsen_velocity(
                         used_eye = "right"
 
                     # Recalculate dt using the chosen eye indices
-                    if cfg.use_fixed_dt and isinstance(selector, AsymmetricNeighborWindowSelector):
+                    if cfg.use_fixed_dt and isinstance(
+                        selector, AsymmetricNeighborWindowSelector
+                    ):
                         if hz_measured is not None and hz_measured > 0:
                             dt_ms = 1000.0 / hz_measured
                         else:
                             t_first = float(times[actual_first_idx])
                             t_last = float(times[actual_last_idx])
                             dt_ms = t_last - t_first
-                    elif isinstance(selector, FixedSampleSymmetricWindowSelector) and hz_measured is not None and hz_measured > 0:
+                    elif (
+                        isinstance(selector, FixedSampleSymmetricWindowSelector)
+                        and hz_measured is not None
+                        and hz_measured > 0
+                    ):
                         window_size = actual_last_idx - actual_first_idx + 1
                         window_spans = window_size - 1
                         dt_ms = window_spans * (1000.0 / hz_measured)
@@ -774,8 +1001,8 @@ def compute_olsen_velocity(
 
             if both_valid.any() and single_valid.any():
                 if use_neighbor:
-                    x1, y1 = impute_avg_with_neighbor(first_idx, first_idx, last_idx)
-                    x2, y2 = impute_avg_with_neighbor(last_idx, first_idx, last_idx)
+                    x1, y1 = neighbor_imputer.impute(first_idx, first_idx, last_idx)
+                    x2, y2 = neighbor_imputer.impute(last_idx, first_idx, last_idx)
                 elif use_single_eye:
                     candidates: List[tuple[str, int]] = []
                     if left_valid[first_idx] and left_valid[last_idx]:
@@ -801,21 +1028,33 @@ def compute_olsen_velocity(
         dir_first = dir_last = None
         if isinstance(velocity_strategy, (Ray3DGazeDir, TobiiGazeDirAngle)):
             dir_first, dir_last = _get_direction_vectors(
-                actual_first_idx, actual_last_idx, eye_mode, used_eye, eye_consistent_override,
-                ldx, ldy, ldz, rdx, rdy, rdz, combined_dir_x, combined_dir_y, combined_dir_z
+                actual_first_idx,
+                actual_last_idx,
+                eye_mode,
+                used_eye,
+                eye_consistent_override,
+                ldx,
+                ldy,
+                ldz,
+                rdx,
+                rdy,
+                rdz,
+                combined_dir_x,
+                combined_dir_y,
+                combined_dir_z,
             )
 
         # Coordinate rounding (optional)
         x1, y1 = coord_rounding.round_gaze(x1, y1)
         x2, y2 = coord_rounding.round_gaze(x2, y2)
-        
+
         # Eye position rounding
         eye_x = cex[i] if i < len(cex) else None
         eye_y = cey[i] if i < len(cey) else None
         eye_z = cz[i] if i < len(cz) else None
         if eye_x is not None and eye_y is not None and eye_z is not None:
             eye_x, eye_y, eye_z = coord_rounding.round_eye(eye_x, eye_y, eye_z)
-        
+
         ctx = VelocityContext(
             x1_mm=x1,
             y1_mm=y1,
@@ -828,20 +1067,14 @@ def compute_olsen_velocity(
             dir2=dir_last,
         )
 
-        angle_deg = velocity_strategy.calculate_visual_angle_ctx(ctx)
-        dt_s = dt_ms / 1000.0
-        raw_velocity = angle_deg / dt_s if dt_s > 0 else float("nan")
-        # Rundung auf 2 Nachkommastellen mit ROUND_HALF_UP, um Banker's Rounding zu vermeiden
-        if not pd.isna(raw_velocity):
-            velocity = float(Decimal(raw_velocity).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
-        else:
-            velocity = raw_velocity
-        df.at[i, "velocity_deg_per_sec"] = velocity
-        df.at[i, "dt_ms"] = dt_ms  # Store the time difference used for velocity
-        # Optional: rohen Wert speichern, falls später benötigt
-        df.at[i, "velocity_raw_deg_per_sec"] = raw_velocity
+        sample_result = VelocitySampleComputer.compute_sample(
+            ctx, dt_ms, velocity_strategy
+        )
+        df.at[i, "velocity_deg_per_sec"] = sample_result.velocity_deg_per_sec
+        df.at[i, "dt_ms"] = sample_result.dt_ms
+        df.at[i, "velocity_raw_deg_per_sec"] = sample_result.raw_velocity_deg_per_sec
         df.at[i, "velocity_eye_used"] = used_eye
-        
+
         # Speichere die tatsächliche Fensterbreite (in Samples)
         final_window_size = last_idx - first_idx + 1
         df.at[i, "window_width_samples"] = final_window_size
@@ -856,67 +1089,21 @@ def compute_olsen_velocity(
             type(selector).__name__,
         )
 
-    # fixed_window_edge_fallback: Wenn Fensterrand invalide Samples hat,
-    # kopiere Velocity vom nächsten Sample mit gültigem Fenster
-    # WICHTIG: Unclassified Samples (durch gap_rule) dürfen NICHT überschrieben werden
-    if cfg.fixed_window_edge_fallback and isinstance(selector, FixedSampleSymmetricWindowSelector):
-        logger.info("Applying fixed_window_edge_fallback strategy...")
-        half_size = selector.half_size
-        fallback_count = 0
-        
-        for i in range(n):
-            # Nur für valide Samples ohne berechnete Velocity
-            if not bool(valid[i]) or not pd.isna(df.at[i, "velocity_deg_per_sec"]):
-                continue
-            
-            # NICHT überschreiben, wenn gap_rule_triggered (= absichtlich Unclassified)
-            if "gap_rule_triggered" in df.columns:
-                if bool(df.at[i, "gap_rule_triggered"]):
-                    continue
-            
-            # Prüfe ob das Problem invalide Fensterränder sind
-            window_start = max(0, i - half_size)
-            window_end = min(n - 1, i + half_size)
-            
-            # Hat das Fenster invalide Samples am Rand?
-            has_invalid_edge = False
-            if window_start < i:  # Links-Rand prüfen
-                if not bool(valid[window_start]):
-                    has_invalid_edge = True
-            if window_end > i:  # Rechts-Rand prüfen
-                if not bool(valid[window_end]):
-                    has_invalid_edge = True
-            
-            if not has_invalid_edge:
-                continue
-            
-            # Suche nächstes Sample mit gültiger Velocity (links und rechts)
-            found_velocity = None
-            search_radius = min(50, n)  # Max 50 Samples suchen
-            
-            for offset in range(1, search_radius):
-                # Erst rechts suchen
-                if i + offset < n and bool(valid[i + offset]):
-                    vel = df.at[i + offset, "velocity_deg_per_sec"]
-                    if not pd.isna(vel):
-                        found_velocity = vel
-                        break
-                # Dann links suchen
-                if i - offset >= 0 and bool(valid[i - offset]):
-                    vel = df.at[i - offset, "velocity_deg_per_sec"]
-                    if not pd.isna(vel):
-                        found_velocity = vel
-                        break
-            
-            if found_velocity is not None:
-                df.at[i, "velocity_deg_per_sec"] = found_velocity
-                fallback_count += 1
-        
-        if fallback_count > 0:
-            logger.info("Applied fallback velocity to %s samples", fallback_count)
+    apply_fixed_window_edge_fallback(
+        df, FixedWindowEdgeFallbackContext(cfg=cfg, selector=selector, valid=valid)
+    )
 
     return df
 
+
+def compute_olsen_velocity(
+    df: pd.DataFrame,
+    cfg: OlsenVelocityConfig,
+) -> pd.DataFrame:
+    """Compute Olsen-style velocity through explicit, testable pipeline stages."""
+    normalized = normalize_timestamps(df, cfg)
+    prepared = prepare_velocity_input(normalized, cfg)
+    return VelocitySampleComputer(cfg).compute(prepared)
 
 
 def compute_olsen_velocity_from_slim_tsv(

--- a/tests/test_velocity_processing_components.py
+++ b/tests/test_velocity_processing_components.py
@@ -1,0 +1,117 @@
+import math
+
+import numpy as np
+import pandas as pd
+
+from ivt_filter.config import OlsenVelocityConfig
+from ivt_filter.processing.velocity import (
+    AverageNeighborImputer,
+    FixedWindowEdgeFallbackContext,
+    SamplingAnalyzer,
+    VelocityInputArrays,
+    VelocitySampleComputer,
+    VelocityStrategyFactory,
+    WindowSelectorFactory,
+    apply_fixed_window_edge_fallback,
+    find_single_eye_endpoints,
+    normalize_timestamps,
+    prepare_velocity_input,
+)
+from ivt_filter.strategies import (
+    FixedSampleSymmetricWindowSelector,
+    Olsen2DApproximation,
+    VelocityContext,
+)
+
+
+def test_normalize_timestamps_converts_microseconds_and_sorts_copy():
+    original = pd.DataFrame({"timestamp": [2000, 1000]})
+    cfg = OlsenVelocityConfig(time_column="timestamp", time_unit="us")
+    result = normalize_timestamps(original, cfg)
+    assert result["time_ms"].tolist() == [1.0, 2.0]
+    assert "time_ms" not in original
+
+
+def test_sampling_analyzer_derives_odd_fixed_sample_window():
+    cfg = OlsenVelocityConfig(window_length_ms=20, auto_fixed_window_from_ms=True)
+    result = SamplingAnalyzer().analyze(np.array([0.0, 10.0, 20.0, 30.0]), cfg)
+    assert result.dt_ms == 10.0
+    assert result.hz_measured == 100.0
+    assert result.config.fixed_window_samples == 3
+
+
+def test_neighbor_imputer_uses_closest_valid_missing_eye_sample():
+    arrays = VelocityInputArrays(
+        times=np.array([0.0, 10.0, 20.0]),
+        combined_x=np.array([0.0, 5.0, 10.0]),
+        combined_y=np.zeros(3),
+        left_valid=np.array([True, True, True]),
+        right_valid=np.array([True, False, True]),
+        valid=np.ones(3, dtype=bool),
+        left_x=np.array([0.0, 10.0, 20.0]),
+        left_y=np.zeros(3),
+        right_x=np.array([2.0, np.nan, 22.0]),
+        right_y=np.zeros(3),
+    )
+    assert AverageNeighborImputer(arrays).impute(1, 0, 2) == (6.0, 0.0)
+
+
+def test_find_single_eye_endpoints_limits_search_to_window():
+    valid = np.array([True, False, True, True, False, True])
+    assert find_single_eye_endpoints(valid, 1, 4) == (2, 3)
+
+
+def test_velocity_sample_computer_calculates_one_structured_result():
+    context = VelocityContext(0, 0, 10, 0, 0, 0, 600)
+    result = VelocitySampleComputer.compute_sample(
+        context, 10.0, Olsen2DApproximation()
+    )
+    expected = math.degrees(math.atan(10 / 600)) / 0.01
+    assert result.velocity_deg_per_sec == round(expected, 2)
+    assert result.dt_ms == 10.0
+
+
+def test_fixed_window_edge_fallback_copies_nearest_velocity():
+    df = pd.DataFrame(
+        {
+            "velocity_deg_per_sec": [np.nan, np.nan, 12.5, np.nan],
+            "gap_rule_triggered": [False] * 4,
+        }
+    )
+    cfg = OlsenVelocityConfig(fixed_window_samples=3, fixed_window_edge_fallback=True)
+    selector = WindowSelectorFactory.create(cfg)
+    assert isinstance(selector, FixedSampleSymmetricWindowSelector)
+    count = apply_fixed_window_edge_fallback(
+        df,
+        FixedWindowEdgeFallbackContext(
+            cfg, selector, np.array([False, True, True, True])
+        ),
+    )
+    assert count == 1
+    assert df.at[1, "velocity_deg_per_sec"] == 12.5
+
+
+def test_prepare_velocity_input_runs_preprocessing_steps_in_order(monkeypatch):
+    calls = []
+
+    def record(name):
+        def apply(df, cfg):
+            calls.append(name)
+            return df.assign(**{name: True})
+
+        return apply
+
+    monkeypatch.setattr("ivt_filter.processing.velocity.gap_fill_gaze", record("gap"))
+    monkeypatch.setattr(
+        "ivt_filter.processing.velocity.prepare_combined_columns", record("combined")
+    )
+    monkeypatch.setattr(
+        "ivt_filter.processing.velocity.smooth_combined_gaze", record("smooth")
+    )
+    result = prepare_velocity_input(pd.DataFrame({"value": [1]}), OlsenVelocityConfig())
+    assert calls == ["gap", "combined", "smooth"]
+    assert result.at[0, "smooth"]
+
+
+def test_velocity_strategy_factory_builds_requested_strategy():
+    assert isinstance(VelocityStrategyFactory.create("olsen2d"), Olsen2DApproximation)


### PR DESCRIPTION
### Motivation
- Break the large, monolithic `compute_olsen_velocity()` implementation into small, focused components to improve testability and clarity.
- Isolate sampling, window selection and velocity-strategy concerns so they can be reasoned about and mocked independently.
- Extract previously nested helper logic (neighbor imputation and single-eye endpoint search) into dedicated, testable units.

### Description
- Introduce explicit pipeline stages and helpers: `normalize_timestamps(df, cfg)` and `prepare_velocity_input(df, cfg)` to handle timestamp normalization and gaze preprocessing. 
- Add analysis/factory and data holder types: `SamplingAnalyzer`, `VelocityStrategyFactory`, `WindowSelectorFactory`, `VelocityInputArrays` (dataclass), and `VelocityComputationResult` to encapsulate sampling results and factory creation. 
- Add per-sample computation and result structs: `VelocitySampleComputer` and `ComputedVelocitySample`, and extract average-neighbor imputation and single-eye endpoint search into `AverageNeighborImputer` and `find_single_eye_endpoints`, respectively. 
- Extract fixed-window edge fallback into `apply_fixed_window_edge_fallback(df, context)` and keep `compute_olsen_velocity()` as a thin facade that coordinates `normalize_timestamps()`, `prepare_velocity_input()` and `VelocitySampleComputer`. 

### Testing
- Ran the full test suite with `pytest -q`, resulting in 130 passed and 1 skipped. 
- Added focused component tests in `tests/test_velocity_processing_components.py` that exercise timestamp normalization, sampling analysis, neighbor imputation, single-eye endpoint selection, per-sample computation, preprocessing order and fixed-window fallback, and these tests passed as part of the suite. 
- Verified the modified module compiles with `python -m py_compile ivt_filter/processing/velocity.py` with no errors.

