### PR TITLE
Fix Python CI lint and type-check failures

### DIFF
--- a/ivt_filter/evaluation/event_iou.py
+++ b/ivt_filter/evaluation/event_iou.py
@@ -27,7 +27,7 @@ Rationale for this approach over simpler "run-based agreement":
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Dict, Any, List, Optional, Tuple
 
 import numpy as np

--- a/ivt_filter/preprocessing/gap_fill.py
+++ b/ivt_filter/preprocessing/gap_fill.py
@@ -155,6 +155,8 @@ def gap_fill_gaze(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataFrame:
                 px_x_prev = px_x_next = px_y_prev = px_y_next = None
 
             # Gaze-Direction-Endpunkte
+            dpx: tuple[float, float, float] | None
+            dnx: tuple[float, float, float] | None
             if dir_x_vals is not None:
                 dpx = (float(dir_x_vals[prev_idx]), float(dir_y_vals[prev_idx]), float(dir_z_vals[prev_idx]))
                 dnx = (float(dir_x_vals[next_idx]), float(dir_y_vals[next_idx]), float(dir_z_vals[next_idx]))
@@ -191,7 +193,7 @@ def gap_fill_gaze(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataFrame:
                     px_y_vals[j] = (1.0 - alpha) * float(px_y_prev) + alpha * float(px_y_next)
 
                 # Gaze-Direction-Vektoren interpolieren und renormieren
-                if dir_endpoints_valid:
+                if dir_endpoints_valid and dpx is not None and dnx is not None:
                     ix = (1.0 - alpha) * dpx[0] + alpha * dnx[0]
                     iy = (1.0 - alpha) * dpx[1] + alpha * dnx[1]
                     iz = (1.0 - alpha) * dpx[2] + alpha * dnx[2]


### PR DESCRIPTION
### Motivation
- Behebt CI-Fehler: `ruff` meldete einen ungenutzten Import und `mypy` beanstandete eine unsichere Indexierung in der Gap-Fill-Interpolation.

### Description
- Entfernt den ungenutzten `dataclasses.field`-Import in `ivt_filter/evaluation/event_iou.py` und deklariert sowie schützt die optionalen Gaze-Richtungsendpunkte `dpx`/`dnx` in `ivt_filter/preprocessing/gap_fill.py` als `tuple[float,float,float] | None`, sodass die Laufzeitlogik unverändert bleibt, aber `mypy` die Indexierung verifizieren kann.

### Testing
- Ausgeführt: `ruff check ivt_filter`, `mypy ivt_filter`, `pytest -q` (134 passed, 1 skipped), `git diff --check` und `python -m compileall -q ivt_filter` — alle berichteten Checks sind erfolgreich; Coverage-/Build-/Docker-Schritte konnten lokal nicht vollständig ausgeführt werden wegen fehlendem `pytest-cov`, fehlendem `build`-Modul und fehlendem Docker sowie einem paket-Proxy, der Paketdownloads blockiert.

