### PR TITLE
Fix default I-VT classifier config and invalid gaze-direction handling

### DIFF
--- a/ivt_filter/core/classification.py
+++ b/ivt_filter/core/classification.py
@@ -6,7 +6,7 @@ import math
 import pandas as pd
 import numpy as np
 
-from ..config import OlsenVelocityConfig as IVTClassifierConfig
+from ..config import IVTClassifierConfig
 from ..strategies import Ray3DAngle
 from ..strategies.coordinate_rounding import NoRounding
 

--- a/ivt_filter/processing/classification.py
+++ b/ivt_filter/processing/classification.py
@@ -6,7 +6,7 @@ import math
 import pandas as pd
 import numpy as np
 
-from ..config import OlsenVelocityConfig as IVTClassifierConfig
+from ..config import IVTClassifierConfig
 from ..strategies import Ray3DAngle
 from ..strategies.coordinate_rounding import NoRounding
 

--- a/ivt_filter/strategies/velocity_calculation.py
+++ b/ivt_filter/strategies/velocity_calculation.py
@@ -239,7 +239,7 @@ class Ray3DGazeDir(VelocityCalculationStrategy):
         dir1 = ctx.dir1
         dir2 = ctx.dir2
         if dir1 is None or dir2 is None:
-            return 0.0
+            return float("nan")
 
         v1 = np.array(dir1, dtype=float)
         v2 = np.array(dir2, dtype=float)
@@ -247,7 +247,7 @@ class Ray3DGazeDir(VelocityCalculationStrategy):
         n1 = np.linalg.norm(v1)
         n2 = np.linalg.norm(v2)
         if n1 == 0.0 or n2 == 0.0 or not np.isfinite(n1) or not np.isfinite(n2):
-            return 0.0
+            return float("nan")
 
         v1 /= n1
         v2 /= n2
@@ -301,7 +301,7 @@ class TobiiGazeDirAngle(VelocityCalculationStrategy):
         dir1 = ctx.dir1
         dir2 = ctx.dir2
         if dir1 is None or dir2 is None:
-            return 0.0
+            return float("nan")
 
         v1 = np.asarray(dir1, dtype=float)
         v2 = np.asarray(dir2, dtype=float)
@@ -310,7 +310,7 @@ class TobiiGazeDirAngle(VelocityCalculationStrategy):
         n2 = float(np.linalg.norm(v2))
 
         if n1 == 0.0 or n2 == 0.0 or not math.isfinite(n1) or not math.isfinite(n2):
-            return 0.0
+            return float("nan")
 
         return self._angle_between_normalized(v1 / n1, v2 / n2)
 
@@ -324,8 +324,8 @@ class TobiiGazeDirAngle(VelocityCalculationStrategy):
         eye_y_mm: Optional[float],
         eye_z_mm: Optional[float],
     ) -> float:
-        # Ohne Richtungsvektoren (dir1/dir2) nicht berechenbar; Fallback: 0°
-        return 0.0
+        # Ohne Richtungsvektoren (dir1/dir2) ist der Winkel nicht berechenbar.
+        return float("nan")
 
     def get_description(self) -> str:
         return (

--- a/tests/test_classification_regressions.py
+++ b/tests/test_classification_regressions.py
@@ -1,0 +1,83 @@
+"""Regression tests for critical I-VT classification behavior."""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ivt_filter.config import IVTClassifierConfig
+from ivt_filter.processing.classification import IVTClassifier, apply_ivt_classifier
+from ivt_filter.processing.velocity import VelocitySampleComputer
+from ivt_filter.strategies.velocity_calculation import (
+    Ray3DGazeDir,
+    TobiiGazeDirAngle,
+    VelocityContext,
+)
+
+
+def _direction_context(dir1, dir2) -> VelocityContext:
+    return VelocityContext(
+        x1_mm=0.0,
+        y1_mm=0.0,
+        x2_mm=0.0,
+        y2_mm=0.0,
+        eye_x_mm=None,
+        eye_y_mm=None,
+        eye_z_mm=None,
+        dir1=dir1,
+        dir2=dir2,
+    )
+
+
+def test_ivt_classifier_uses_classifier_config_by_default() -> None:
+    classifier = IVTClassifier()
+
+    assert isinstance(classifier.cfg, IVTClassifierConfig)
+
+
+def test_apply_ivt_classifier_uses_default_config_and_classifies_velocities() -> None:
+    df = pd.DataFrame({"velocity_deg_per_sec": [1.0, 100.0, np.nan]})
+
+    result = apply_ivt_classifier(df)
+
+    assert result["ivt_sample_type"].tolist() == [
+        "Fixation",
+        "Saccade",
+        "Unclassified",
+    ]
+
+
+@pytest.mark.parametrize("strategy", [Ray3DGazeDir(), TobiiGazeDirAngle()])
+@pytest.mark.parametrize(
+    ("dir1", "dir2"),
+    [
+        (None, (1.0, 0.0, 0.0)),
+        ((1.0, 0.0, 0.0), None),
+        ((0.0, 0.0, 0.0), (1.0, 0.0, 0.0)),
+        ((np.nan, 0.0, 0.0), (1.0, 0.0, 0.0)),
+        ((np.inf, 0.0, 0.0), (1.0, 0.0, 0.0)),
+    ],
+    ids=["dir1-missing", "dir2-missing", "zero-vector", "nan-vector", "inf-vector"],
+)
+def test_direction_strategy_returns_nan_for_uncomputable_angle(
+    strategy, dir1, dir2
+) -> None:
+    angle = strategy.calculate_visual_angle_ctx(_direction_context(dir1, dir2))
+
+    assert math.isnan(angle)
+
+
+def test_missing_direction_produces_nan_velocity_and_unclassified_sample() -> None:
+    sample = VelocitySampleComputer.compute_sample(
+        _direction_context(None, (1.0, 0.0, 0.0)),
+        dt_ms=10.0,
+        strategy=Ray3DGazeDir(),
+    )
+
+    result = apply_ivt_classifier(
+        pd.DataFrame({"velocity_deg_per_sec": [sample.velocity_deg_per_sec]})
+    )
+
+    assert math.isnan(sample.velocity_deg_per_sec)
+    assert result.at[0, "ivt_sample_type"] == "Unclassified"

--- a/tests/test_tobii_compat.py
+++ b/tests/test_tobii_compat.py
@@ -122,21 +122,21 @@ class TestTobiiGazeDirAngle:
         angle = self.strat.calculate_visual_angle_ctx(self._ctx(v1, v2))
         assert angle == pytest.approx(90.0, abs=1e-6)
 
-    def test_zero_vector_returns_zero(self):
-        """Nullvektor → 0° (kein Crash)."""
+    def test_zero_vector_returns_nan(self):
+        """Nullvektor → NaN, da der Winkel nicht berechenbar ist."""
         v1 = np.array([0.0, 0.0, 0.0])
         v2 = _make_unit_vec(0, 0, 1)
         angle = self.strat.calculate_visual_angle_ctx(self._ctx(v1, v2))
-        assert angle == 0.0
+        assert math.isnan(angle)
 
-    def test_none_direction_returns_zero(self):
-        """Fehlende Richtung (None) → 0°."""
+    def test_none_direction_returns_nan(self):
+        """Fehlende Richtung (None) → NaN."""
         ctx = VelocityContext(
             x1_mm=0.0, y1_mm=0.0, x2_mm=0.0, y2_mm=0.0,
             eye_x_mm=None, eye_y_mm=None, eye_z_mm=None,
             dir1=None, dir2=_make_unit_vec(0, 0, 1),
         )
-        assert self.strat.calculate_visual_angle_ctx(ctx) == 0.0
+        assert math.isnan(self.strat.calculate_visual_angle_ctx(ctx))
 
     def test_consistent_with_ray3d_gaze_dir_for_moderate_angles(self):
         """Für moderate Winkel (<90°) sollten TobiiGazeDirAngle und Ray3DGazeDir


### PR DESCRIPTION
### Motivation
- Der I‑VT‑Klassifikator importierte versehentlich `OlsenVelocityConfig` unter dem Alias `IVTClassifierConfig`, sodass `IVTClassifier()` und `apply_ivt_classifier(df)` ohne explizite Config nicht zuverlässig funktionierten.
- `Ray3DGazeDir` und `TobiiGazeDirAngle` lieferten bei fehlenden, nicht-finiten oder Null‑Richtungsvektoren fälschlich `0.0°`, was künstliche Fixationen erzeugen kann; fachlich korrekt ist hier eine nicht berechenbare Größe (`NaN`).

### Description
- Korrigiert die Importe in `ivt_filter/processing/classification.py` und der Legacy‑Kopie `ivt_filter/core/classification.py`, so dass `IVTClassifierConfig` aus `ivt_filter.config` verwendet wird (Standardkonstruktor funktioniert wieder).
- Ändert `Ray3DGazeDir` und `TobiiGazeDirAngle` in `ivt_filter/strategies/velocity_calculation.py` so, dass sie bei fehlenden, nicht-finiten oder Null‑Vektoren `float("nan")` zurückgeben und somit keine gültige Velocity liefern.
- Passt den Tobii‑Fallback (`calculate_visual_angle` ohne `dir1/dir2`) an, sodass er `NaN` statt `0.0` liefert, da der Winkel nicht berechenbar ist.
- Fügt `tests/test_classification_regressions.py` hinzu, die: (a) prüfen, dass `IVTClassifier()` das richtige Default‑`IVTClassifierConfig` erhält, (b) `apply_ivt_classifier(df)` ohne Config funktioniert und Fixation/Saccade/Unclassified korrekt priorisiert, (c) sicherstellen, dass beide Direction‑Strategien bei fehlenden/ungültigen Vektoren `NaN` zurückgeben und dass daraus eine `NaN`‑Velocity und damit `Unclassified` resultiert; und aktualisiert relevante Erwartungen in `tests/test_tobii_compat.py`.

### Testing
- `pytest -q` — Gesamtlauf: `147 passed, 1 skipped` (inkl. neuen Regressionstests).
- `ruff check ivt_filter` — bestanden.
- `mypy ivt_filter` — bestanden (keine Fehler in Quelldateien).
- Zusätzlich wurden gezielt `pytest -q tests/test_classification_regressions.py tests/test_tobii_compat.py tests/test_strategies_new.py` und `ruff check tests/test_classification_regressions.py` ausgeführt; alle bestanden.

