### PR TITLE
Stabilize public imports and make plotting optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
+Plotting is optional. Install the plotting extra only if you want to generate figures:
+
+```bash
+pip install tobii-ivt-filter[plot]
+```
+
+### Supported Python Import Paths
+
+Use the canonical module paths below in applications and examples. The package does not
+maintain duplicate root-level compatibility modules for these APIs.
+
+| API | Supported import path |
+|-----|-----------------------|
+| `IVTPipeline` | `ivt_filter.io.pipeline` |
+| `PipelineObserver`, `ConsoleReporter`, `MetricsLogger`, `ExperimentTracker`, `ResultsPlotter` | `ivt_filter.io.observers` |
+| `ExperimentConfig`, `ExperimentManager` | `ivt_filter.evaluation.experiment` |
+| `estimate_sampling_rate` | `ivt_filter.utils.sampling` |
+| Window sizing helpers | `ivt_filter.utils.window_utils` |
+
 ### 2. Prepare Your Data
 
 The filter expects TSV (tab-separated values) with these columns:

--- a/example_experiment_tracking.py
+++ b/example_experiment_tracking.py
@@ -14,9 +14,9 @@ Usage:
 from pathlib import Path
 
 from ivt_filter.config import OlsenVelocityConfig, IVTClassifierConfig
-from ivt_filter.experiment import ExperimentConfig, ExperimentManager
-from ivt_filter.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
-from ivt_filter.pipeline import IVTPipeline
+from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+from ivt_filter.io.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
+from ivt_filter.io.pipeline import IVTPipeline
 
 
 def run_single_experiment():

--- a/example_sample_based_window.py
+++ b/example_sample_based_window.py
@@ -17,10 +17,10 @@ from pathlib import Path
 import pandas as pd
 
 from ivt_filter.config import OlsenVelocityConfig, IVTClassifierConfig
-from ivt_filter.experiment import ExperimentConfig, ExperimentManager
-from ivt_filter.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
-from ivt_filter.pipeline import IVTPipeline
-from ivt_filter.sampling import estimate_sampling_rate
+from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+from ivt_filter.io.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
+from ivt_filter.io.pipeline import IVTPipeline
+from ivt_filter.utils.sampling import estimate_sampling_rate
 from ivt_filter.io import read_tsv
 
 

--- a/example_window_sweep.py
+++ b/example_window_sweep.py
@@ -10,9 +10,9 @@ Usage:
 from pathlib import Path
 
 from ivt_filter.config import OlsenVelocityConfig, IVTClassifierConfig
-from ivt_filter.experiment import ExperimentConfig, ExperimentManager
-from ivt_filter.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
-from ivt_filter.pipeline import IVTPipeline
+from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+from ivt_filter.io.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
+from ivt_filter.io.pipeline import IVTPipeline
 
 
 def window_length_sweep():

--- a/ivt_filter/__init__.py
+++ b/ivt_filter/__init__.py
@@ -1,20 +1,25 @@
-# ivt_filter/__init__.py
-"""
-IVT Filter Package.
+"""Tobii I-VT filter reconstruction package."""
+from __future__ import annotations
 
-Enthält:
-- Olsen Velocity Berechnung
-- I VT Klassifikation
-- Post Processing
-- Evaluation und Plotting
-"""
+from typing import Any
 
 from .config import OlsenVelocityConfig
 from .processing.velocity import compute_olsen_velocity, compute_olsen_velocity_from_slim_tsv
 from .processing.classification import apply_ivt_classifier
 from .postprocess import merge_short_saccade_blocks
 from .evaluation.evaluation import evaluate_ivt_vs_ground_truth, compute_ivt_metrics
-from .evaluation.plotting import plot_velocity_only, plot_velocity_and_classification  # optional
+
+_PLOTTING_EXPORTS = {"plot_velocity_only", "plot_velocity_and_classification"}
+
+
+def __getattr__(name: str) -> Any:
+    """Load plotting helpers lazily so importing the package does not need matplotlib."""
+    if name in _PLOTTING_EXPORTS:
+        from .evaluation import plotting
+
+        return getattr(plotting, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "OlsenVelocityConfig",

--- a/ivt_filter/_optional_dependencies.py
+++ b/ivt_filter/_optional_dependencies.py
@@ -1,0 +1,18 @@
+"""Helpers for loading optional runtime dependencies."""
+from __future__ import annotations
+
+from importlib import import_module
+from importlib.util import find_spec
+from types import ModuleType
+
+
+PLOT_INSTALL_HINT = "pip install tobii-ivt-filter[plot]"
+
+
+def require_matplotlib_pyplot() -> ModuleType:
+    """Load pyplot or explain how to install the optional plotting extra."""
+    if find_spec("matplotlib") is None:
+        raise ModuleNotFoundError(
+            "Plotting requires matplotlib. Install it with: " + PLOT_INSTALL_HINT
+        )
+    return import_module("matplotlib.pyplot")

--- a/ivt_filter/evaluation/__init__.py
+++ b/ivt_filter/evaluation/__init__.py
@@ -1,7 +1,9 @@
-"""Evaluation: analysis, validation, and visualization tools."""
+"""Evaluation: analysis, validation, and optional visualization tools."""
+from __future__ import annotations
+
+from typing import Any
 
 from .evaluation import compute_ivt_metrics, evaluate_ivt_vs_ground_truth
-from .plotting import plot_velocity_only, plot_velocity_and_classification
 from .experiment import ExperimentConfig, ExperimentManager
 from .event_iou import (
     Event,
@@ -13,19 +15,31 @@ from .event_iou import (
     format_event_iou_report,
 )
 
+_PLOTTING_EXPORTS = {"plot_velocity_only", "plot_velocity_and_classification"}
+
+
+def __getattr__(name: str) -> Any:
+    """Load plotting helpers lazily so matplotlib remains optional."""
+    if name in _PLOTTING_EXPORTS:
+        from . import plotting
+
+        return getattr(plotting, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
-    'compute_ivt_metrics',
-    'evaluate_ivt_vs_ground_truth',
-    'plot_velocity_only',
-    'plot_velocity_and_classification',
-    'ExperimentConfig',
-    'ExperimentManager',
+    "compute_ivt_metrics",
+    "evaluate_ivt_vs_ground_truth",
+    "plot_velocity_only",
+    "plot_velocity_and_classification",
+    "ExperimentConfig",
+    "ExperimentManager",
     # Maximum IoU event-level evaluation (Startsev & Zemblys, 2022)
-    'Event',
-    'MatchResult',
-    'extract_events',
-    'compute_iou',
-    'match_events_max_iou',
-    'compute_event_iou_metrics',
-    'format_event_iou_report',
+    "Event",
+    "MatchResult",
+    "extract_events",
+    "compute_iou",
+    "match_events_max_iou",
+    "compute_event_iou_metrics",
+    "format_event_iou_report",
 ]

--- a/ivt_filter/evaluation/plotting.py
+++ b/ivt_filter/evaluation/plotting.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 
 from typing import Optional
 import pandas as pd
-import matplotlib.pyplot as plt
+from .._optional_dependencies import require_matplotlib_pyplot
 
 from ..config import OlsenVelocityConfig
+
+
+plt = require_matplotlib_pyplot()
 
 
 def plot_velocity_only(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> None:

--- a/ivt_filter/io/__init__.py
+++ b/ivt_filter/io/__init__.py
@@ -1,14 +1,22 @@
-"""I/O and pipeline utilities."""
+"""I/O, pipeline, and observer utilities."""
 
 from .io import read_tsv, write_tsv
 from .pipeline import IVTPipeline
-from .observers import MetricsLogger, ResultsPlotter, ConsoleReporter
+from .observers import (
+    ConsoleReporter,
+    ExperimentTracker,
+    MetricsLogger,
+    PipelineObserver,
+    ResultsPlotter,
+)
 
 __all__ = [
     "read_tsv",
     "write_tsv",
     "IVTPipeline",
-    "MetricsLogger",
-    "ResultsPlotter",
+    "PipelineObserver",
     "ConsoleReporter",
+    "MetricsLogger",
+    "ExperimentTracker",
+    "ResultsPlotter",
 ]

--- a/ivt_filter/io/observers.py
+++ b/ivt_filter/io/observers.py
@@ -6,8 +6,8 @@ This module implements the Observer Pattern to decouple pipeline execution
 from logging, visualization, and metric tracking.
 
 Example:
-    >>> from observers import MetricsLogger, ResultsPlotter, ConsoleReporter
-    >>> from pipeline import IVTPipeline
+    >>> from ivt_filter.io.observers import MetricsLogger, ResultsPlotter, ConsoleReporter
+    >>> from ivt_filter.io.pipeline import IVTPipeline
     >>> 
     >>> # Create pipeline
     >>> pipeline = IVTPipeline(velocity_config, classifier_config)
@@ -325,7 +325,9 @@ class ResultsPlotter(PipelineObserver):
         """Generate and save plots."""
         try:
             from ..evaluation.plotting import plot_velocity_only, plot_velocity_and_classification
-            import matplotlib.pyplot as plt
+            from .._optional_dependencies import require_matplotlib_pyplot
+
+            plt = require_matplotlib_pyplot()
             
             for plot_type in self.plot_types:
                 if plot_type == "velocity":
@@ -346,6 +348,8 @@ class ResultsPlotter(PipelineObserver):
             if self.auto_show:
                 plt.show()
         
+        except ImportError:
+            raise
         except Exception as e:
             print(f"Warning: Could not generate plots: {e}")
     

--- a/ivt_filter/io/pipeline.py
+++ b/ivt_filter/io/pipeline.py
@@ -22,7 +22,6 @@ from ..processing.velocity import compute_olsen_velocity
 from ..processing.classification import apply_ivt_classifier, expand_gt_events_to_samples
 from ..postprocess import merge_short_saccade_blocks, apply_fixation_postprocessing
 from ..evaluation.evaluation import evaluate_ivt_vs_ground_truth, compute_ivt_metrics
-from ..evaluation.plotting import plot_velocity_only, plot_velocity_and_classification
 
 
 class IVTPipeline:
@@ -36,8 +35,8 @@ class IVTPipeline:
         - Notify observers of pipeline events (Observer Pattern)
     
     Example:
-        >>> from observers import ConsoleReporter, MetricsLogger, ExperimentTracker
-        >>> from experiment import ExperimentConfig
+        >>> from ivt_filter.io.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
+        >>> from ivt_filter.evaluation.experiment import ExperimentConfig
         >>> 
         >>> pipeline = IVTPipeline(velocity_config, classifier_config)
         >>> pipeline.register_observer(ConsoleReporter())
@@ -135,7 +134,7 @@ class IVTPipeline:
             Processed DataFrame
         
         Example:
-            >>> from experiment import ExperimentConfig
+            >>> from ivt_filter.evaluation.experiment import ExperimentConfig
             >>> config = ExperimentConfig(
             ...     name="olsen2d_20ms_30deg",
             ...     description="Baseline configuration",
@@ -345,7 +344,9 @@ class IVTPipeline:
         return df, "ivt_event_type_post"
 
     def _generate_plots(self, df: pd.DataFrame, with_events: bool) -> None:
-        """Generate visualization plots."""
+        """Generate visualization plots, loading matplotlib only when requested."""
+        from ..evaluation.plotting import plot_velocity_only, plot_velocity_and_classification
+
         if with_events:
             plot_velocity_and_classification(df, self.velocity_config)
         else:

--- a/ivt_filter/utils/__init__.py
+++ b/ivt_filter/utils/__init__.py
@@ -1,17 +1,25 @@
-"""Utility functions for window management and sampling rate detection."""
+"""Sampling and window-sizing utility helpers."""
 
+from .sampling import estimate_sampling_rate
 from .window_utils import (
-    samples_to_milliseconds,
-    milliseconds_to_samples,
+    create_adaptive_config,
+    create_sample_based_config,
+    create_time_based_config,
     detect_sampling_rate,
-)
-from .sampling import (
-    KNOWN_SAMPLING_RATES,
+    milliseconds_to_samples,
+    print_window_info,
+    recommend_window_size,
+    samples_to_milliseconds,
 )
 
 __all__ = [
-    'samples_to_milliseconds',
-    'milliseconds_to_samples',
-    'detect_sampling_rate',
-    'KNOWN_SAMPLING_RATES',
+    "estimate_sampling_rate",
+    "samples_to_milliseconds",
+    "milliseconds_to_samples",
+    "detect_sampling_rate",
+    "create_time_based_config",
+    "create_sample_based_config",
+    "create_adaptive_config",
+    "print_window_info",
+    "recommend_window_size",
 ]

--- a/quick_window_test.py
+++ b/quick_window_test.py
@@ -6,9 +6,9 @@ Usage:
     python quick_window_test.py
 """
 from ivt_filter.config import OlsenVelocityConfig, IVTClassifierConfig
-from ivt_filter.experiment import ExperimentConfig, ExperimentManager
-from ivt_filter.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
-from ivt_filter.pipeline import IVTPipeline
+from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+from ivt_filter.io.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
+from ivt_filter.io.pipeline import IVTPipeline
 
 # Input file
 INPUT_FILE = "I-VT-frequency120Fixation_input.tsv"
@@ -20,51 +20,59 @@ WINDOW_SIZES = [1.0, 10.0, 20.0, 40.0, 60.0]
 THRESHOLD = 30.0
 METHOD = "olsen2d"
 
-print(f"\n🔬 Testing {len(WINDOW_SIZES)} different window sizes...")
+def main() -> None:
+    """Run the quick window-size sweep and print a comparison."""
+    print(f"\n🔬 Testing {len(WINDOW_SIZES)} different window sizes...")
 
-for window_ms in WINDOW_SIZES:
-    # Create configs
-    velocity_config = OlsenVelocityConfig(
-        window_length_ms=window_ms,
-        velocity_method=METHOD,
-        eye_mode="average",
+    for window_ms in WINDOW_SIZES:
+        # Create configs
+        velocity_config = OlsenVelocityConfig(
+            window_length_ms=window_ms,
+            velocity_method=METHOD,
+            eye_mode="average",
+        )
+
+        classifier_config = IVTClassifierConfig(
+            velocity_threshold_deg_per_sec=THRESHOLD,
+        )
+
+        exp_config = ExperimentConfig(
+            name=f"quick_window_{int(window_ms)}ms",
+            description=f"Quick test: {window_ms} ms window",
+            velocity_config=velocity_config,
+            classifier_config=classifier_config,
+            tags=["quick_test", f"window_{int(window_ms)}ms"],
+        )
+
+        # Create pipeline with observers
+        pipeline = IVTPipeline(velocity_config, classifier_config)
+        pipeline.register_observer(ConsoleReporter(verbose=False))
+        pipeline.register_observer(MetricsLogger("experiments/quick_metrics.csv"))
+        pipeline.register_observer(ExperimentTracker("experiments"))
+
+        # Run
+        try:
+            pipeline.run_with_tracking(INPUT_FILE, exp_config, evaluate=True)
+            print(f"  ✅ {window_ms} ms - Done!")
+        except Exception as e:
+            print(f"  ❌ {window_ms} ms - Error: {e}")
+
+    # Compare results
+    print("\n📊 Comparing results...")
+    manager = ExperimentManager("experiments")
+    quick_exps = [e["name"] for e in manager.list_experiments(tags=["quick_test"])]
+    comparison = manager.compare_experiments(quick_exps)
+
+    print("\nResults:")
+    print(comparison[["experiment", "window_ms", "percentage_agreement",
+                      "fixation_recall", "saccade_recall"]].to_string(index=False))
+
+    # Find best
+    best_name, best_value, _ = manager.get_best_configuration(
+        "percentage_agreement", tags=["quick_test"]
     )
-    
-    classifier_config = IVTClassifierConfig(
-        velocity_threshold_deg_per_sec=THRESHOLD,
-    )
-    
-    exp_config = ExperimentConfig(
-        name=f"quick_window_{int(window_ms)}ms",
-        description=f"Quick test: {window_ms} ms window",
-        velocity_config=velocity_config,
-        classifier_config=classifier_config,
-        tags=["quick_test", f"window_{int(window_ms)}ms"],
-    )
-    
-    # Create pipeline with observers
-    pipeline = IVTPipeline(velocity_config, classifier_config)
-    pipeline.register_observer(ConsoleReporter(verbose=False))
-    pipeline.register_observer(MetricsLogger("experiments/quick_metrics.csv"))
-    pipeline.register_observer(ExperimentTracker("experiments"))
-    
-    # Run
-    try:
-        df = pipeline.run_with_tracking(INPUT_FILE, exp_config, evaluate=True)
-        print(f"  ✅ {window_ms} ms - Done!")
-    except Exception as e:
-        print(f"  ❌ {window_ms} ms - Error: {e}")
+    print(f"\n🏆 Best window: {best_name} with {best_value:.2f}% agreement")
 
-# Compare results
-print(f"\n📊 Comparing results...")
-manager = ExperimentManager("experiments")
-quick_exps = [e["name"] for e in manager.list_experiments(tags=["quick_test"])]
-comparison = manager.compare_experiments(quick_exps)
 
-print("\nResults:")
-print(comparison[["experiment", "window_ms", "percentage_agreement", 
-                 "fixation_recall", "saccade_recall"]].to_string(index=False))
-
-# Find best
-best_name, best_value, _ = manager.get_best_configuration("percentage_agreement", tags=["quick_test"])
-print(f"\n🏆 Best window: {best_name} with {best_value:.2f}% agreement")
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pytest
 numpy 
 pandas 
-matplotlib
+# Optional plotting: pip install tobii-ivt-filter[plot]
 joblib  # Optional: for parallel processing (recommended for large datasets)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,4 +1,171 @@
-"""Smoke tests for the public simple API imports."""
+"""Smoke tests for supported public imports and optional plotting behavior."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import subprocess
+import sys
+
+import pandas as pd
+import pytest
+
+from ivt_filter.config import OlsenVelocityConfig
+
+
+REPOSITORY_ROOT = Path(__file__).parent.parent
+EXAMPLE_MODULES = [
+    "example_experiment_tracking.py",
+    "example_sample_based_window.py",
+    "example_window_sweep.py",
+    "quick_window_test.py",
+]
+
+
+def test_import_package() -> None:
+    import ivt_filter
+
+    assert ivt_filter.__name__ == "ivt_filter"
+
+
+def test_import_canonical_public_api() -> None:
+    from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+    from ivt_filter.io.observers import (
+        ConsoleReporter,
+        ExperimentTracker,
+        MetricsLogger,
+        PipelineObserver,
+        ResultsPlotter,
+    )
+    from ivt_filter.io.pipeline import IVTPipeline
+    from ivt_filter.utils.sampling import estimate_sampling_rate
+    from ivt_filter.utils.window_utils import (
+        create_adaptive_config,
+        create_sample_based_config,
+        create_time_based_config,
+        detect_sampling_rate,
+        milliseconds_to_samples,
+        print_window_info,
+        recommend_window_size,
+        samples_to_milliseconds,
+    )
+
+    assert all(
+        callable(public_object)
+        for public_object in [
+            IVTPipeline,
+            ExperimentConfig,
+            ExperimentManager,
+            PipelineObserver,
+            ConsoleReporter,
+            MetricsLogger,
+            ExperimentTracker,
+            ResultsPlotter,
+            estimate_sampling_rate,
+            samples_to_milliseconds,
+            milliseconds_to_samples,
+            detect_sampling_rate,
+            create_time_based_config,
+            create_sample_based_config,
+            create_adaptive_config,
+            print_window_info,
+            recommend_window_size,
+        ]
+    )
+
+
+def test_import_convenience_subpackages() -> None:
+    from ivt_filter.io import ExperimentTracker, IVTPipeline, PipelineObserver, ResultsPlotter
+    from ivt_filter.utils import estimate_sampling_rate, samples_to_milliseconds
+
+    assert all(
+        callable(public_object)
+        for public_object in [
+            IVTPipeline,
+            PipelineObserver,
+            ExperimentTracker,
+            ResultsPlotter,
+            estimate_sampling_rate,
+            samples_to_milliseconds,
+        ]
+    )
+
+
+@pytest.mark.parametrize("example_file", EXAMPLE_MODULES)
+def test_import_executable_example_without_running_it(
+    example_file: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module_path = REPOSITORY_ROOT / example_file
+    monkeypatch.chdir(tmp_path)
+    spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+
+    before = set(tmp_path.iterdir())
+    spec.loader.exec_module(module)
+
+    assert set(tmp_path.iterdir()) == before
+
+
+def test_core_imports_work_without_matplotlib() -> None:
+    script = """
+import importlib.abc
+import sys
+
+class MatplotlibBlocker(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname == "matplotlib" or fullname.startswith("matplotlib."):
+            raise AssertionError(f"core import requested optional dependency: {fullname}")
+        return None
+
+sys.meta_path.insert(0, MatplotlibBlocker())
+import ivt_filter
+import ivt_filter.evaluation
+from ivt_filter.io.pipeline import IVTPipeline
+from ivt_filter.io.observers import ResultsPlotter
+print("optional plotting dependency was not imported")
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "optional plotting dependency was not imported" in completed.stdout
+
+
+def test_plotting_error_explains_optional_extra_when_matplotlib_is_unavailable() -> None:
+    script = """
+import importlib.util
+original_find_spec = importlib.util.find_spec
+import ivt_filter._optional_dependencies as optional_dependencies
+optional_dependencies.find_spec = lambda name: None if name == "matplotlib" else original_find_spec(name)
+from ivt_filter.evaluation.plotting import plot_velocity_only
+"""
+    completed = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=REPOSITORY_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert completed.returncode != 0
+    assert "pip install tobii-ivt-filter[plot]" in completed.stderr
+
+
+def test_plotting_works_when_matplotlib_is_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    pytest.importorskip("matplotlib")
+    from matplotlib import pyplot as plt
+    from ivt_filter.evaluation.plotting import plot_velocity_only
+
+    monkeypatch.setattr(plt, "show", lambda: None)
+    df = pd.DataFrame({"time_ms": [0.0, 1.0], "velocity_deg_per_sec": [1.0, 2.0]})
+    config = OlsenVelocityConfig(window_length_ms=20.0)
+
+    plot_velocity_only(df, config)
+    assert plt.gcf().axes
+    plt.close("all")
 
 
 def test_import_process_eye_tracking() -> None:


### PR DESCRIPTION
### Motivation

- Define and stabilise a small set of canonical public import paths so external code and examples use a consistent API surface.
- Repair executable examples so they import supported modules and can be imported without side effects.
- Make plotting truly optional so core package imports do not require `matplotlib` and users get a clear installation hint when plotting is requested.

### Description

- Documented the supported import paths in `README.md` and updated examples to import from canonical modules such as `ivt_filter.io.pipeline`, `ivt_filter.io.observers`, `ivt_filter.evaluation.experiment`, and `ivt_filter.utils.*`.
- Added `ivt_filter/_optional_dependencies.py` and changed plotting code to load `matplotlib` lazily; `ivt_filter.__getattr__` and `ivt_filter.evaluation.__getattr__` expose plotting helpers on demand so normal imports do not import `matplotlib`.
- Updated `IVTPipeline` and `ResultsPlotter` to import plotting functions only at plot time, and to raise a clear error recommending `pip install tobii-ivt-filter[plot]` when `matplotlib` is missing.
- Protected executable code in examples by ensuring processing runs are behind `if __name__ == "__main__":` and moved `quick_window_test.py` logic into a `main()` function so example modules can be imported without executing them.
- Added convenience exports for the public I/O and utils APIs (`ivt_filter.io` and `ivt_filter.utils`) without duplicating implementation logic.
- Removed eager `matplotlib` from `requirements.txt` and documented the optional plotting extra in `README.md`.
- Added smoke tests `tests/test_public_api.py` that validate package import, canonical imports, example import without execution, core imports when `matplotlib` is blocked, and plotting behaviour when `matplotlib` is present or absent.

### Testing

- Ran `pytest -q` and all tests passed: `157 passed, 1 skipped`.
- Ran `ruff check ivt_filter` and it reported: `All checks passed!`.
- Ran `mypy ivt_filter` and it reported: `Success: no issues found in 43 source files`.
