### PR TITLE
Persist actual Velocity endpoint metadata for classifier refinements

### DIFF
--- a/ivt_filter/processing/classification.py
+++ b/ivt_filter/processing/classification.py
@@ -167,7 +167,13 @@ class IVTClassifier:
         eye_jump_flags = np.zeros(n, dtype=bool)
         refinement_reasons = [""] * n
         
-        # Check if we have window_width_samples column to infer window structure
+        # Velocity computation persists the actual endpoints. Externally supplied
+        # DataFrames may not have that metadata, so retain the legacy symmetric
+        # reconstruction only when both endpoint columns are entirely absent.
+        has_endpoint_metadata = {
+            "velocity_first_idx",
+            "velocity_last_idx",
+        }.issubset(df.columns)
         has_window_width = "window_width_samples" in df.columns
         
         for i in range(n):
@@ -178,8 +184,18 @@ class IVTClassifier:
             if not np.isfinite(velocity_base):
                 continue
             
-            # Infer window indices (symmetric around i based on window_width_samples)
-            if has_window_width:
+            if has_endpoint_metadata:
+                first_value = df.at[i, "velocity_first_idx"]
+                last_value = df.at[i, "velocity_last_idx"]
+                if pd.isna(first_value) or pd.isna(last_value):
+                    continue
+                first_idx = int(first_value)
+                last_idx = int(last_value)
+                if not (0 <= first_idx < n and 0 <= last_idx < n):
+                    continue
+            elif has_window_width:
+                # Compatibility fallback for externally supplied DataFrames made
+                # before Velocity endpoint metadata was introduced.
                 window_width = df.at[i, "window_width_samples"]
                 if pd.notna(window_width):
                     half_width = int(window_width) // 2
@@ -188,7 +204,7 @@ class IVTClassifier:
                 else:
                     continue
             else:
-                # Default: use 3-sample window (i-1, i, i+1)
+                # Compatibility fallback for minimal external DataFrames.
                 first_idx = max(0, i - 1)
                 last_idx = min(n - 1, i + 1)
             

--- a/ivt_filter/processing/velocity.py
+++ b/ivt_filter/processing/velocity.py
@@ -521,12 +521,26 @@ def apply_fixed_window_edge_fallback(
                 if 0 <= candidate < len(df) and bool(valid[candidate]):
                     velocity = df.at[candidate, "velocity_deg_per_sec"]
                     if not pd.isna(velocity):
-                        found = velocity
+                        found = candidate, velocity
                         break
             if found is not None:
                 break
         if found is not None:
-            df.at[i, "velocity_deg_per_sec"] = found
+            source_idx, velocity = found
+            df.at[i, "velocity_deg_per_sec"] = velocity
+            for column in (
+                "dt_ms",
+                "velocity_raw_deg_per_sec",
+                "window_width_samples",
+                "velocity_first_idx",
+                "velocity_last_idx",
+                "velocity_eye_used",
+                "velocity_window_selector",
+            ):
+                if column in df.columns:
+                    df.at[i, column] = df.at[source_idx, column]
+            if "velocity_fallback_applied" in df.columns:
+                df.at[i, "velocity_fallback_applied"] = True
             count += 1
     if count:
         logger.info("Applied fallback velocity to %s samples", count)
@@ -583,7 +597,11 @@ def _compute_olsen_velocity_impl(
     df["dt_ms"] = float("nan")  # Time difference used for velocity calculation
     df["window_width_samples"] = pd.NA  # New column for Fensterbreite
     df["window_any_invalid"] = False  # Track if any eye invalid in the used window
-    df["velocity_eye_used"] = "average"  # Diagnostic: which eye contributed to velocity
+    df["velocity_first_idx"] = pd.NA
+    df["velocity_last_idx"] = pd.NA
+    df["velocity_eye_used"] = pd.NA
+    df["velocity_window_selector"] = pd.NA
+    df["velocity_fallback_applied"] = pd.NA
     # Debug/Transparenz: Umgebung-Validitäts-Flags
     df["env_has_invalid_above"] = pd.NA
     df["env_has_invalid_below"] = pd.NA
@@ -745,7 +763,9 @@ def _compute_olsen_velocity_impl(
             continue
 
         # 1. Versuch: aktueller Selector (z.B. SampleSymmetric oder FixedSample)
+        selected_selector = selector
         first_idx, last_idx = selector.select(i, times, valid, half_window)
+        fallback_applied = bool(getattr(selector, "last_fallback_applied", False))
 
         # 2. Fallback: wenn kein sinnvolles Fenster gefunden wurde,
         #    versuche noch das klassische Zeitfenster
@@ -761,6 +781,8 @@ def _compute_olsen_velocity_impl(
                 and first_idx_fb != last_idx_fb
             ):
                 first_idx, last_idx = first_idx_fb, last_idx_fb
+                selected_selector = fallback_selector
+                fallback_applied = True
 
         # Wenn immer noch kein Fenster: Velocity bleibt NaN -> Sample bleibt Unclassified
         if first_idx is None or last_idx is None or first_idx == last_idx:
@@ -793,6 +815,7 @@ def _compute_olsen_velocity_impl(
                 for j in range(first_idx + 1, last_idx + 1):
                     if valid[j]:
                         first_idx = j
+                        fallback_applied = True
                         break
                 else:
                     continue  # Kein gültiges Sample gefunden
@@ -802,6 +825,7 @@ def _compute_olsen_velocity_impl(
                 for j in range(last_idx - 1, first_idx - 1, -1):
                     if valid[j]:
                         last_idx = j
+                        fallback_applied = True
                         break
                 else:
                     continue  # Kein gültiges Sample gefunden
@@ -817,7 +841,7 @@ def _compute_olsen_velocity_impl(
 
         # Berechne Zeitdifferenz (nutzt Window-Selector-Typ)
         dt_ms = _calculate_dt_ms(
-            first_idx, last_idx, times, selector, hz_measured, cfg.use_fixed_dt
+            first_idx, last_idx, times, selected_selector, hz_measured, cfg.use_fixed_dt
         )
 
         # Track the actual endpoints used for velocity and direction lookup
@@ -852,7 +876,7 @@ def _compute_olsen_velocity_impl(
                 actual_first_idx,
                 actual_last_idx,
                 times,
-                selector,
+                selected_selector,
                 hz_measured,
                 cfg.use_fixed_dt,
             )
@@ -932,6 +956,7 @@ def _compute_olsen_velocity_impl(
                         chosen_eye = "left" if score_left > score_right else "right"
 
                     # Find valid endpoints for chosen eye (with fallback search inside window)
+                    fallback_applied = True
                     if chosen_eye == "left":
                         if left_first is not None:
                             actual_first_idx = left_first
@@ -968,7 +993,7 @@ def _compute_olsen_velocity_impl(
 
                     # Recalculate dt using the chosen eye indices
                     if cfg.use_fixed_dt and isinstance(
-                        selector, AsymmetricNeighborWindowSelector
+                        selected_selector, AsymmetricNeighborWindowSelector
                     ):
                         if hz_measured is not None and hz_measured > 0:
                             dt_ms = 1000.0 / hz_measured
@@ -977,14 +1002,14 @@ def _compute_olsen_velocity_impl(
                             t_last = float(times[actual_last_idx])
                             dt_ms = t_last - t_first
                     elif (
-                        isinstance(selector, FixedSampleSymmetricWindowSelector)
+                        isinstance(selected_selector, FixedSampleSymmetricWindowSelector)
                         and hz_measured is not None
                         and hz_measured > 0
                     ):
                         window_size = actual_last_idx - actual_first_idx + 1
                         window_spans = window_size - 1
                         dt_ms = window_spans * (1000.0 / hz_measured)
-                    elif isinstance(selector, ShiftedValidWindowSelector):
+                    elif isinstance(selected_selector, ShiftedValidWindowSelector):
                         # Shifted valid window: use actual timestamps
                         t_first = float(times[actual_first_idx])
                         t_last = float(times[actual_last_idx])
@@ -1073,10 +1098,14 @@ def _compute_olsen_velocity_impl(
         df.at[i, "velocity_deg_per_sec"] = sample_result.velocity_deg_per_sec
         df.at[i, "dt_ms"] = sample_result.dt_ms
         df.at[i, "velocity_raw_deg_per_sec"] = sample_result.raw_velocity_deg_per_sec
+        df.at[i, "velocity_first_idx"] = actual_first_idx
+        df.at[i, "velocity_last_idx"] = actual_last_idx
         df.at[i, "velocity_eye_used"] = used_eye
+        df.at[i, "velocity_window_selector"] = type(selected_selector).__name__
+        df.at[i, "velocity_fallback_applied"] = fallback_applied
 
         # Speichere die tatsächliche Fensterbreite (in Samples)
-        final_window_size = last_idx - first_idx + 1
+        final_window_size = actual_last_idx - actual_first_idx + 1
         df.at[i, "window_width_samples"] = final_window_size
 
     # Transparenz: Fenster-Statistik ausgeben

--- a/ivt_filter/strategies/windowing.py
+++ b/ivt_filter/strategies/windowing.py
@@ -191,6 +191,7 @@ class TimeBasedShiftedValidWindowSelector(WindowSelector):
 			raise ValueError("fallback_mode must be 'shrink' or 'unclassified'.")
 		self.fallback_mode = fallback_mode
 		self._fallback_selector = TimeSymmetricWindowSelector()
+		self.last_fallback_applied = False
 
 	def select(
 		self,
@@ -199,6 +200,7 @@ class TimeBasedShiftedValidWindowSelector(WindowSelector):
 		valid: np.ndarray,
 		half_window_ms: float,
 	) -> IndexPair:
+		self.last_fallback_applied = False
 		if not bool(valid[idx]):
 			return None, None
 
@@ -255,6 +257,7 @@ class TimeBasedShiftedValidWindowSelector(WindowSelector):
 			if new_start >= n or not valid[new_start]:
 				# Fallback
 				if self.fallback_mode == "shrink":
+					self.last_fallback_applied = True
 					return self._fallback_selector.select(idx, times, valid, half_window_ms)
 				return None, None
 
@@ -282,6 +285,7 @@ class TimeBasedShiftedValidWindowSelector(WindowSelector):
 			if new_end < 0 or not valid[new_end]:
 				# Fallback
 				if self.fallback_mode == "shrink":
+					self.last_fallback_applied = True
 					return self._fallback_selector.select(idx, times, valid, half_window_ms)
 				return None, None
 
@@ -305,6 +309,7 @@ class TimeBasedShiftedValidWindowSelector(WindowSelector):
 
 		# Fallback
 		if self.fallback_mode == "shrink":
+			self.last_fallback_applied = True
 			return self._fallback_selector.select(idx, times, valid, half_window_ms)
 		return None, None
 
@@ -408,6 +413,7 @@ class ShiftedValidWindowSelector(WindowSelector):
 		self.half_size = int(half_size)
 		self.fallback_mode = fallback_mode
 		self._fallback_selector = FixedSampleSymmetricWindowSelector(half_size)
+		self.last_fallback_applied = False
 
 	def select(
 		self,
@@ -416,6 +422,7 @@ class ShiftedValidWindowSelector(WindowSelector):
 		valid: np.ndarray,
 		half_window_ms: float,
 	) -> IndexPair:
+		self.last_fallback_applied = False
 		if not bool(valid[idx]):
 			return None, None
 
@@ -504,5 +511,6 @@ class ShiftedValidWindowSelector(WindowSelector):
 
 		# Fallback
 		if self.fallback_mode == "shrink":
+			self.last_fallback_applied = True
 			return self._fallback_selector.select(idx, times, valid, half_window_ms)
 		return None, None

--- a/tests/test_velocity_endpoint_metadata.py
+++ b/tests/test_velocity_endpoint_metadata.py
@@ -1,0 +1,183 @@
+"""Regression tests for persisted Velocity endpoint metadata."""
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ivt_filter.config import IVTClassifierConfig, OlsenVelocityConfig
+from ivt_filter.processing.classification import IVTClassifier
+from ivt_filter.processing.velocity import compute_olsen_velocity
+
+
+def _gaze_df(n: int = 8) -> pd.DataFrame:
+    gaze = np.arange(n, dtype=float) * 5.0
+    return pd.DataFrame(
+        {
+            "time_ms": np.arange(n, dtype=float) * 10.0,
+            "gaze_left_x_mm": gaze,
+            "gaze_left_y_mm": np.zeros(n),
+            "gaze_right_x_mm": gaze,
+            "gaze_right_y_mm": np.zeros(n),
+            "eye_left_x_mm": np.zeros(n),
+            "eye_left_y_mm": np.zeros(n),
+            "eye_left_z_mm": np.full(n, 600.0),
+            "eye_right_x_mm": np.zeros(n),
+            "eye_right_y_mm": np.zeros(n),
+            "eye_right_z_mm": np.full(n, 600.0),
+            "validity_left": np.zeros(n, dtype=int),
+            "validity_right": np.zeros(n, dtype=int),
+        }
+    )
+
+
+def _metadata(result: pd.DataFrame, idx: int) -> tuple[int, int, str, bool]:
+    return (
+        int(result.at[idx, "velocity_first_idx"]),
+        int(result.at[idx, "velocity_last_idx"]),
+        str(result.at[idx, "velocity_window_selector"]),
+        bool(result.at[idx, "velocity_fallback_applied"]),
+    )
+
+
+def test_symmetric_window_persists_actual_endpoints_for_computed_samples() -> None:
+    result = compute_olsen_velocity(
+        _gaze_df(), OlsenVelocityConfig(fixed_window_samples=3)
+    )
+
+    assert _metadata(result, 0) == (0, 1, "FixedSampleSymmetricWindowSelector", False)
+    assert _metadata(result, 3) == (2, 4, "FixedSampleSymmetricWindowSelector", False)
+    assert _metadata(result, 7) == (6, 7, "FixedSampleSymmetricWindowSelector", False)
+    computed = result["velocity_deg_per_sec"].notna()
+    assert result.loc[computed, "velocity_first_idx"].notna().all()
+    assert result.loc[computed, "velocity_last_idx"].notna().all()
+    assert result.loc[computed, "velocity_eye_used"].eq("average").all()
+    assert result.loc[computed, "velocity_window_selector"].notna().all()
+    assert result.loc[computed, "velocity_fallback_applied"].notna().all()
+
+
+def test_asymmetric_neighbor_window_persists_backward_and_forward_endpoints() -> None:
+    df = _gaze_df(4)
+    df.loc[0, ["validity_left", "validity_right"]] = 999
+    result = compute_olsen_velocity(
+        df, OlsenVelocityConfig(asymmetric_neighbor_window=True)
+    )
+
+    assert _metadata(result, 1) == (1, 2, "AsymmetricNeighborWindowSelector", False)
+    assert _metadata(result, 2) == (1, 2, "AsymmetricNeighborWindowSelector", False)
+
+
+def test_shifted_valid_window_persists_shifted_endpoints() -> None:
+    df = _gaze_df()
+    df.loc[2, ["validity_left", "validity_right"]] = 999
+    result = compute_olsen_velocity(
+        df,
+        OlsenVelocityConfig(
+            fixed_window_samples=3,
+            shifted_valid_window=True,
+            shifted_valid_fallback="unclassified",
+        ),
+    )
+
+    assert _metadata(result, 3) == (3, 5, "ShiftedValidWindowSelector", False)
+
+
+def test_shifted_valid_window_marks_internal_shrink_fallback() -> None:
+    df = _gaze_df()
+    df.loc[4, ["validity_left", "validity_right"]] = 999
+    result = compute_olsen_velocity(
+        df,
+        OlsenVelocityConfig(
+            fixed_window_samples=5,
+            shifted_valid_window=True,
+            shifted_valid_fallback="shrink",
+        ),
+    )
+
+    assert _metadata(result, 3) == (1, 5, "ShiftedValidWindowSelector", True)
+
+
+def test_sample_symmetric_selector_records_time_selector_fallback() -> None:
+    result = compute_olsen_velocity(
+        _gaze_df(),
+        OlsenVelocityConfig(window_length_ms=20.0, sample_symmetric_window=True),
+    )
+
+    assert _metadata(result, 0) == (0, 1, "TimeSymmetricWindowSelector", True)
+
+
+def test_time_window_records_valid_sample_endpoint_adjustment() -> None:
+    df = _gaze_df(7)
+    df.loc[1, ["validity_left", "validity_right"]] = 999
+    result = compute_olsen_velocity(df, OlsenVelocityConfig(window_length_ms=40.0))
+
+    assert _metadata(result, 3) == (2, 5, "TimeSymmetricWindowSelector", True)
+
+
+def test_single_eye_fallback_persists_adjusted_eye_endpoints() -> None:
+    df = _gaze_df(7)
+    df.loc[[0, 1, 6], "validity_left"] = 999
+    df.loc[[0, 4, 5, 6], "validity_right"] = 999
+    result = compute_olsen_velocity(
+        df,
+        OlsenVelocityConfig(
+            fixed_window_samples=5,
+            average_fallback_single_eye=True,
+        ),
+    )
+
+    assert _metadata(result, 3) == (2, 5, "FixedSampleSymmetricWindowSelector", True)
+    assert result.at[3, "velocity_eye_used"] == "left"
+    assert result.at[3, "window_width_samples"] == 4
+
+
+def _refinement_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "time_ms": [0.0, 10.0, 20.0, 30.0, 40.0],
+            "smoothed_x_mm": [0.0, 2.0, 4.0, 8.0, 20.0],
+            "smoothed_y_mm": [0.0] * 5,
+            "eye_x_mm": [0.0] * 5,
+            "eye_y_mm": [0.0] * 5,
+            "eye_z_mm": [600.0] * 5,
+            "combined_valid": [True] * 5,
+            "velocity_deg_per_sec": [30.0] * 5,
+            "window_width_samples": [pd.NA, 4, pd.NA, pd.NA, pd.NA],
+        }
+    )
+
+
+def _ray_velocity(x1: float, x2: float, dt_ms: float) -> float:
+    angle = math.degrees(math.atan2(x2, 600.0) - math.atan2(x1, 600.0))
+    return round(angle / (dt_ms / 1000.0), 1)
+
+
+def _classifier() -> IVTClassifier:
+    return IVTClassifier(
+        IVTClassifierConfig(
+            enable_near_threshold_hybrid=True,
+            near_threshold_band=1000.0,
+            near_threshold_strategy="replace",
+        )
+    )
+
+
+def test_refinement_prefers_persisted_actual_endpoints() -> None:
+    df = _refinement_df()
+    df["velocity_first_idx"] = pd.NA
+    df["velocity_last_idx"] = pd.NA
+    df.at[1, "velocity_first_idx"] = 1
+    df.at[1, "velocity_last_idx"] = 4
+
+    result = _classifier().classify(df)
+
+    assert result.at[1, "velocity_refined"] == pytest.approx(_ray_velocity(2.0, 20.0, 30.0))
+
+
+def test_refinement_keeps_legacy_symmetric_fallback_for_external_dataframe_edges() -> None:
+    df = _refinement_df().drop(columns="window_width_samples")
+
+    result = _classifier().classify(df)
+
+    assert result.at[0, "velocity_refined"] == pytest.approx(_ray_velocity(0.0, 2.0, 10.0))


### PR DESCRIPTION
### Motivation
- Persist the actual Velocity endpoint metadata so downstream classifier refinements use the real endpoints instead of reconstructed symmetric windows.
- Ensure the recorded endpoints reflect the final indices after selector resolution, fallback selector resolution, fallback valid-sample search, shifted-window handling, asymmetric-neighbor handling, single-eye fallback, and endpoint adjustment.
- Preserve backward compatibility by keeping a documented fallback for externally supplied DataFrames that lack endpoint metadata.

### Description
- Write per-sample metadata columns in the velocity pipeline: `velocity_first_idx`, `velocity_last_idx`, `velocity_eye_used`, `velocity_window_selector`, and `velocity_fallback_applied`, and make `window_width_samples` reflect the final actual endpoints.
- Track the resolved selector and fallback state (`selected_selector`, `fallback_applied`) and use the resolved selector for endpoint-dependent timing (`_calculate_dt_ms`) and shifted-window fallback observability by adding `last_fallback_applied` to shifted selectors.
- Preserve and copy endpoint and diagnostic metadata when `apply_fixed_window_edge_fallback` fills velocities from nearby computed samples and mark such copied samples as fallback-derived.
- Update `IVTClassifier._precompute_refinements()` to prefer `velocity_first_idx`/`velocity_last_idx` when present and only reconstruct symmetric windows from `window_width_samples` as a compatibility fallback for external DataFrames without endpoint metadata.

### Testing
- Ran `pytest -q` and observed `169 passed, 1 skipped`, with focused endpoint tests included (new `tests/test_velocity_endpoint_metadata.py`).
- Ran `ruff check ivt_filter` with no reported issues.
- Ran `mypy ivt_filter` with no type errors reported.
- Added focused regression tests covering symmetric windows, `AsymmetricNeighborWindowSelector`, `ShiftedValidWindowSelector` (shift and shrink fallback), selector fallback behavior, single-eye fallback, DataFrame edge cases, and externally supplied DataFrames without metadata, all of which passed.
