### PR TITLE
Centralize I‑VT domain rules and DataFrame stage contracts

### DIFF
--- a/ivt_filter/domain/__init__.py
+++ b/ivt_filter/domain/__init__.py
@@ -1,0 +1,10 @@
+"""Shared domain rules and lightweight DataFrame stage contracts."""
+
+from .events import iter_contiguous_events, rebuild_events_from_sample_labels
+from .validity import parse_tobii_validity
+
+__all__ = [
+    "iter_contiguous_events",
+    "parse_tobii_validity",
+    "rebuild_events_from_sample_labels",
+]

--- a/ivt_filter/domain/events.py
+++ b/ivt_filter/domain/events.py
@@ -1,0 +1,80 @@
+"""Rules for reconstructing contiguous I-VT events from sample labels."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Sequence
+from dataclasses import dataclass
+
+import pandas as pd
+
+from .schema import require_columns
+
+INDEXED_EVENT_TYPES = frozenset({"Fixation", "Saccade"})
+
+
+@dataclass(frozen=True)
+class ContiguousEvent:
+    """One contiguous run of a sample label, using inclusive positions."""
+
+    label: str
+    start: int
+    end: int
+
+
+def iter_contiguous_events(labels: Iterable[object]) -> Iterator[ContiguousEvent]:
+    """Yield contiguous runs from sample labels, including unclassified runs."""
+    iterator = iter(labels)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return
+
+    label = str(first)
+    start = 0
+    end = 0
+    for position, value in enumerate(iterator, start=1):
+        end = position
+        next_label = str(value)
+        if next_label != label:
+            yield ContiguousEvent(label, start, position - 1)
+            label = next_label
+            start = position
+    yield ContiguousEvent(label, start, end)
+
+
+def assign_event_indices(
+    labels: Sequence[object],
+) -> tuple[list[str], list[int | None]]:
+    """Assign sequential indices to Fixation/Saccade runs.
+
+    Non-event labels such as ``Unclassified`` and ``EyesNotFound`` retain their
+    label, receive no index, and reset contiguity for the next indexed event.
+    """
+    event_types: list[str] = []
+    event_indices: list[int | None] = []
+    next_index = 0
+
+    for event in iter_contiguous_events(labels):
+        length = event.end - event.start + 1
+        event_types.extend([event.label] * length)
+        if event.label in INDEXED_EVENT_TYPES:
+            next_index += 1
+            event_indices.extend([next_index] * length)
+        else:
+            event_indices.extend([None] * length)
+
+    return event_types, event_indices
+
+
+def rebuild_events_from_sample_labels(
+    df: pd.DataFrame,
+    sample_col: str,
+    event_type_col: str,
+    event_index_col: str,
+) -> pd.DataFrame:
+    """Populate event type and index columns from contiguous sample labels."""
+    require_columns(df, (sample_col,), stage="event reconstruction")
+    event_types, event_indices = assign_event_indices(df[sample_col].tolist())
+    df[event_type_col] = event_types
+    df[event_index_col] = event_indices
+    return df

--- a/ivt_filter/domain/schema.py
+++ b/ivt_filter/domain/schema.py
@@ -1,0 +1,71 @@
+"""Lightweight DataFrame stage contracts for the I-VT pipeline."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import pandas as pd
+
+TIME_MS = "time_ms"
+GAZE_LEFT_X_MM = "gaze_left_x_mm"
+GAZE_LEFT_Y_MM = "gaze_left_y_mm"
+GAZE_RIGHT_X_MM = "gaze_right_x_mm"
+GAZE_RIGHT_Y_MM = "gaze_right_y_mm"
+VALIDITY_LEFT = "validity_left"
+VALIDITY_RIGHT = "validity_right"
+COMBINED_X_MM = "combined_x_mm"
+COMBINED_Y_MM = "combined_y_mm"
+COMBINED_VALID = "combined_valid"
+SMOOTHED_X_MM = "smoothed_x_mm"
+SMOOTHED_Y_MM = "smoothed_y_mm"
+VELOCITY_DEG_PER_SEC = "velocity_deg_per_sec"
+IVT_SAMPLE_TYPE = "ivt_sample_type"
+IVT_EVENT_TYPE = "ivt_event_type"
+IVT_EVENT_INDEX = "ivt_event_index"
+
+RAW_GAZE_COLUMNS = (
+    TIME_MS,
+    GAZE_LEFT_X_MM,
+    GAZE_LEFT_Y_MM,
+    GAZE_RIGHT_X_MM,
+    GAZE_RIGHT_Y_MM,
+    VALIDITY_LEFT,
+    VALIDITY_RIGHT,
+)
+PREPROCESSED_COLUMNS = RAW_GAZE_COLUMNS + (
+    COMBINED_X_MM,
+    COMBINED_Y_MM,
+    COMBINED_VALID,
+    SMOOTHED_X_MM,
+    SMOOTHED_Y_MM,
+)
+VELOCITY_COLUMNS = (VELOCITY_DEG_PER_SEC,)
+CLASSIFIED_COLUMNS = (IVT_SAMPLE_TYPE, IVT_EVENT_TYPE, IVT_EVENT_INDEX)
+
+
+def require_columns(df: pd.DataFrame, required: Iterable[str], *, stage: str) -> None:
+    """Raise a clear error when a DataFrame omits stage-required columns."""
+    missing = sorted(set(required).difference(df.columns))
+    if missing:
+        columns = ", ".join(repr(column) for column in missing)
+        raise ValueError(f"{stage} DataFrame is missing required columns: {columns}")
+
+
+def validate_raw_gaze_frame(df: pd.DataFrame) -> None:
+    """Validate normalized raw gaze input before preprocessing."""
+    require_columns(df, RAW_GAZE_COLUMNS, stage="raw gaze")
+
+
+def validate_preprocessed_frame(df: pd.DataFrame) -> None:
+    """Validate gaze input after eye selection and smoothing."""
+    require_columns(df, PREPROCESSED_COLUMNS, stage="preprocessed gaze")
+
+
+def validate_velocity_frame(df: pd.DataFrame) -> None:
+    """Validate classifier input after velocity computation."""
+    require_columns(df, VELOCITY_COLUMNS, stage="velocity")
+
+
+def validate_classified_frame(df: pd.DataFrame) -> None:
+    """Validate classifier output after event reconstruction."""
+    require_columns(df, CLASSIFIED_COLUMNS, stage="classified")

--- a/ivt_filter/domain/validity.py
+++ b/ivt_filter/domain/validity.py
@@ -1,0 +1,25 @@
+"""Tobii validity-code parsing rules."""
+
+from __future__ import annotations
+
+
+INVALID_VALIDITY = 999
+
+
+def parse_tobii_validity(value: object) -> int:
+    """Return a normalized Tobii validity code.
+
+    ``Valid`` maps to ``0`` and ``Invalid`` or values that cannot be parsed map
+    to ``999``. Numeric strings and numeric values use their integer value.
+    """
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized == "valid":
+            return 0
+        if normalized == "invalid":
+            return INVALID_VALIDITY
+
+    try:
+        return int(value)  # type: ignore[call-overload]
+    except (TypeError, ValueError, OverflowError):
+        return INVALID_VALIDITY

--- a/ivt_filter/postprocess.py
+++ b/ivt_filter/postprocess.py
@@ -8,49 +8,13 @@ from typing import Optional, List, Tuple, Dict, Any
 import pandas as pd
 
 from .config import SaccadeMergeConfig, FixationPostConfig
+from .domain.events import iter_contiguous_events, rebuild_events_from_sample_labels
 from .postprocessing.merge_fixations import merge_adjacent_fixations as _merge_adjacent_fixations_internal
 from .postprocessing.discard_short_fixations import discard_short_fixations as _discard_short_fixations_internal
 
 
-def _rebuild_ivt_events_from_sample_types(
-    df: pd.DataFrame,
-    sample_col: str,
-    event_type_col: str,
-    event_index_col: str,
-) -> pd.DataFrame:
-    """
-    Aus einer Sample-Label-Spalte (Fixation/Saccade/Unclassified)
-    wieder Events (zusammenhängende Blöcke) aufbauen.
-
-    Verantwortlichkeit:
-      - nimmt eine Sample-Spalte (z.B. 'ivt_sample_type_smoothed')
-      - erzeugt Event-Type/Index-Spalten
-    """
-    sample_labels = df[sample_col].astype(str).tolist()
-
-    new_event_type: List[str] = []
-    new_event_index: List[Optional[int]] = []
-
-    current_type: Optional[str] = None
-    current_index: int = 0
-
-    for label in sample_labels:
-        if label not in ("Fixation", "Saccade"):
-            new_event_type.append(label)
-            new_event_index.append(None)
-            current_type = None
-            continue
-
-        if label != current_type:
-            current_index += 1
-            current_type = label
-
-        new_event_type.append(label)
-        new_event_index.append(current_index)
-
-    df[event_type_col] = new_event_type
-    df[event_index_col] = new_event_index
-    return df
+# Backward-compatible private alias; event rules live in domain.events.
+_rebuild_ivt_events_from_sample_types = rebuild_events_from_sample_labels
 
 
 
@@ -98,21 +62,11 @@ def merge_short_saccade_blocks(
     n = len(df)
 
     # Find saccade blocks (zusammenhängende "Saccade"-Segmente)
-    blocks: List[Tuple[int, int]] = []
-    in_block = False
-    start_idx = 0
-
-    for i in range(n):
-        if ivt[i] == "Saccade":
-            if not in_block:
-                in_block = True
-                start_idx = i
-        else:
-            if in_block:
-                blocks.append((start_idx, i - 1))
-                in_block = False
-    if in_block:
-        blocks.append((start_idx, n - 1))
+    blocks: List[Tuple[int, int]] = [
+        (event.start, event.end)
+        for event in iter_contiguous_events(ivt)
+        if event.label == "Saccade"
+    ]
 
     changed_blocks = 0
     changed_samples = 0

--- a/ivt_filter/preprocessing/eye_selection.py
+++ b/ivt_filter/preprocessing/eye_selection.py
@@ -11,27 +11,10 @@ import pandas as pd
 from ..config import OlsenVelocityConfig
 
 
-def _parse_validity(value) -> int:
-    """
-    Tobii-Validity robust parsen.
+from ..domain.validity import parse_tobii_validity
 
-    - "Valid"   -> 0
-    - "Invalid" -> 999
-    - numeric strings (0,1,2,...) -> int(value)
-    - ints/floats -> int(value)
-    - alles andere -> 999
-    """
-    if isinstance(value, str):
-        v = value.strip().lower()
-        if v == "valid":
-            return 0
-        if v == "invalid":
-            return 999
-
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return 999
+# Backward-compatible private alias; parsing rules live in domain.validity.
+_parse_validity = parse_tobii_validity
 
 
 def _combine_gaze_and_eye(

--- a/ivt_filter/preprocessing/gap_fill.py
+++ b/ivt_filter/preprocessing/gap_fill.py
@@ -9,27 +9,7 @@ import pandas as pd
 from ..config import OlsenVelocityConfig
 
 
-def _parse_validity(value) -> int:
-    """
-    Tobii-Validity robust parsen.
-
-    - "Valid"   -> 0
-    - "Invalid" -> 999
-    - numeric strings (0,1,2,...) -> int(value)
-    - ints/floats -> int(value)
-    - alles andere -> 999
-    """
-    if isinstance(value, str):
-        v = value.strip().lower()
-        if v == "valid":
-            return 0
-        if v == "invalid":
-            return 999
-
-    try:
-        return int(value)
-    except (TypeError, ValueError):
-        return 999
+from ..domain.validity import parse_tobii_validity
 
 
 def gap_fill_gaze(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataFrame:
@@ -92,7 +72,7 @@ def gap_fill_gaze(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataFrame:
         # Validitaetscodes parsen (falls vorhanden)
         if val_col in df.columns:
             val_series = df[val_col].copy()
-            v_codes = val_series.map(_parse_validity).to_numpy()
+            v_codes = val_series.map(parse_tobii_validity).to_numpy()
         else:
             val_series = None
             v_codes = None

--- a/ivt_filter/processing/classification.py
+++ b/ivt_filter/processing/classification.py
@@ -1,12 +1,14 @@
 # ivt_filter/core/classification.py
 from __future__ import annotations
 
-from typing import Optional, List
+from typing import Optional
 import math
 import pandas as pd
 import numpy as np
 
 from ..config import IVTClassifierConfig
+from ..domain.events import rebuild_events_from_sample_labels
+from ..domain.schema import validate_classified_frame, validate_velocity_frame
 from ..strategies import Ray3DAngle
 from ..strategies.coordinate_rounding import NoRounding
 
@@ -101,8 +103,7 @@ class IVTClassifier:
         Returns:
             DataFrame with added classification columns
         """
-        if "velocity_deg_per_sec" not in df.columns:
-            raise ValueError("DataFrame must contain 'velocity_deg_per_sec'")
+        validate_velocity_frame(df)
 
         df = df.copy()
         self._df_context = df  # Store for alternative velocity access
@@ -134,13 +135,14 @@ class IVTClassifier:
         
         df["ivt_sample_type"] = df.apply(self._classify_sample, axis=1)
 
-        df = rebuild_ivt_events_from_sample_types(
+        df = rebuild_events_from_sample_labels(
             df,
             sample_col="ivt_sample_type",
             event_type_col="ivt_event_type",
             event_index_col="ivt_event_index",
         )
         
+        validate_classified_frame(df)
         self._df_context = None  # Clean up
         return df
     
@@ -443,40 +445,5 @@ def apply_ivt_classifier(
     return classifier.classify(df)
 
 
-def rebuild_ivt_events_from_sample_types(
-    df: pd.DataFrame,
-    sample_col: str,
-    event_type_col: str,
-    event_index_col: str,
-) -> pd.DataFrame:
-    """
-    Bilde Event Typen und Indizes aus sample basierten Labels.
-
-    - Fixation/Saccade Bloecke bekommen fortlaufende Indizes.
-    - Alles andere (z B Unclassified) bekommt None als Index.
-    """
-    sample_labels = df[sample_col].astype(str).tolist()
-
-    new_event_type: List[str] = []
-    new_event_index: List[Optional[int]] = []
-
-    current_type: Optional[str] = None
-    current_index: int = 0
-
-    for label in sample_labels:
-        if label not in ("Fixation", "Saccade"):
-            new_event_type.append(label)
-            new_event_index.append(None)
-            current_type = None
-            continue
-
-        if label != current_type:
-            current_index += 1
-            current_type = label
-
-        new_event_type.append(label)
-        new_event_index.append(current_index)
-
-    df[event_type_col] = new_event_type
-    df[event_index_col] = new_event_index
-    return df
+# Backward-compatible public alias; event rules live in domain.events.
+rebuild_ivt_events_from_sample_types = rebuild_events_from_sample_labels

--- a/ivt_filter/processing/velocity.py
+++ b/ivt_filter/processing/velocity.py
@@ -11,6 +11,7 @@ import numpy as np
 import pandas as pd
 
 from ..config import OlsenVelocityConfig, PhysicalConstants
+from ..domain.schema import validate_preprocessed_frame, validate_raw_gaze_frame
 from ..preprocessing import (
     prepare_combined_columns,
     smooth_combined_gaze,
@@ -422,11 +423,14 @@ def normalize_timestamps(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataF
 
 def prepare_velocity_input(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataFrame:
     """Run gaze preprocessing required before velocity sample computation."""
+    validate_raw_gaze_frame(df)
     result = gap_fill_gaze(df, cfg)
     if getattr(cfg, "tobii_eye_offset_interpolation", False):
         result = apply_tobii_eye_offset_interpolation(result, cfg)
     result = prepare_combined_columns(result, cfg)
-    return smooth_combined_gaze(result, cfg)
+    result = smooth_combined_gaze(result, cfg)
+    validate_preprocessed_frame(result)
+    return result
 
 
 def find_single_eye_endpoints(
@@ -580,6 +584,7 @@ class VelocitySampleComputer:
         return ComputedVelocitySample(velocity, raw_velocity, dt_ms)
 
     def compute(self, prepared_df: pd.DataFrame) -> pd.DataFrame:
+        validate_preprocessed_frame(prepared_df)
         return _compute_olsen_velocity_impl(prepared_df, self.cfg)
 
 

--- a/tests/test_domain_rules.py
+++ b/tests/test_domain_rules.py
@@ -1,0 +1,121 @@
+"""Tests for centralized domain rules and lightweight stage contracts."""
+
+import math
+
+import pandas as pd
+import pytest
+
+from ivt_filter.config import OlsenVelocityConfig
+from ivt_filter.domain.events import (
+    assign_event_indices,
+    iter_contiguous_events,
+    rebuild_events_from_sample_labels,
+)
+from ivt_filter.domain.schema import (
+    CLASSIFIED_COLUMNS,
+    PREPROCESSED_COLUMNS,
+    RAW_GAZE_COLUMNS,
+    VELOCITY_DEG_PER_SEC,
+    validate_classified_frame,
+    validate_preprocessed_frame,
+    validate_raw_gaze_frame,
+    validate_velocity_frame,
+)
+from ivt_filter.domain.validity import INVALID_VALIDITY, parse_tobii_validity
+from ivt_filter.processing.classification import apply_ivt_classifier
+from ivt_filter.processing.velocity import compute_olsen_velocity
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Valid", 0),
+        (" invalid ", INVALID_VALIDITY),
+        ("2", 2),
+        (3, 3),
+        (2.9, 2),
+        (None, INVALID_VALIDITY),
+        ("unknown", INVALID_VALIDITY),
+        (math.inf, INVALID_VALIDITY),
+    ],
+)
+def test_parse_tobii_validity(value: object, expected: int) -> None:
+    assert parse_tobii_validity(value) == expected
+
+
+def test_event_reconstruction_supports_empty_frames() -> None:
+    result = rebuild_events_from_sample_labels(
+        pd.DataFrame({"sample": pd.Series(dtype=str)}),
+        "sample",
+        "event_type",
+        "event_index",
+    )
+
+    assert result.empty
+    assert result.columns.tolist() == ["sample", "event_type", "event_index"]
+
+
+def test_single_sample_is_one_event() -> None:
+    assert assign_event_indices(["Fixation"]) == (["Fixation"], [1])
+
+
+def test_event_indices_reset_contiguity_after_non_event_labels() -> None:
+    labels = [
+        "Fixation",
+        "Fixation",
+        "Saccade",
+        "Fixation",
+        "Unclassified",
+        "Fixation",
+        "EyesNotFound",
+        "Saccade",
+    ]
+
+    assert assign_event_indices(labels) == (
+        labels,
+        [1, 1, 2, 3, None, 4, None, 5],
+    )
+
+
+def test_contiguous_event_iteration_includes_non_event_labels() -> None:
+    events = list(iter_contiguous_events(["Fixation", "Saccade", "Saccade", "EyesNotFound"]))
+
+    assert [(event.label, event.start, event.end) for event in events] == [
+        ("Fixation", 0, 0),
+        ("Saccade", 1, 2),
+        ("EyesNotFound", 3, 3),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("validator", "columns", "stage", "missing"),
+    [
+        (validate_raw_gaze_frame, RAW_GAZE_COLUMNS, "raw gaze", "time_ms"),
+        (validate_preprocessed_frame, PREPROCESSED_COLUMNS, "preprocessed gaze", "smoothed_x_mm"),
+        (validate_velocity_frame, (VELOCITY_DEG_PER_SEC,), "velocity", VELOCITY_DEG_PER_SEC),
+        (validate_classified_frame, CLASSIFIED_COLUMNS, "classified", "ivt_event_index"),
+    ],
+)
+def test_stage_contracts_report_missing_required_columns(
+    validator, columns: tuple[str, ...], stage: str, missing: str
+) -> None:
+    frame = pd.DataFrame(columns=[column for column in columns if column != missing])
+
+    with pytest.raises(ValueError, match=rf"{stage} DataFrame is missing required columns: '{missing}'"):
+        validator(frame)
+
+
+def test_velocity_pipeline_supports_empty_raw_frames() -> None:
+    result = compute_olsen_velocity(
+        pd.DataFrame(columns=RAW_GAZE_COLUMNS), OlsenVelocityConfig()
+    )
+
+    assert result.empty
+    assert VELOCITY_DEG_PER_SEC in result.columns
+
+
+def test_classification_empty_frame_preserves_explicit_contract() -> None:
+    result = apply_ivt_classifier(pd.DataFrame({VELOCITY_DEG_PER_SEC: pd.Series(dtype=float)}))
+
+    assert result.empty
+    assert set(CLASSIFIED_COLUMNS).issubset(result.columns)

--- a/tests/test_velocity_processing_components.py
+++ b/tests/test_velocity_processing_components.py
@@ -108,7 +108,25 @@ def test_prepare_velocity_input_runs_preprocessing_steps_in_order(monkeypatch):
     monkeypatch.setattr(
         "ivt_filter.processing.velocity.smooth_combined_gaze", record("smooth")
     )
-    result = prepare_velocity_input(pd.DataFrame({"value": [1]}), OlsenVelocityConfig())
+    result = prepare_velocity_input(
+        pd.DataFrame(
+            {
+                "time_ms": [0.0],
+                "gaze_left_x_mm": [0.0],
+                "gaze_left_y_mm": [0.0],
+                "gaze_right_x_mm": [0.0],
+                "gaze_right_y_mm": [0.0],
+                "validity_left": [0],
+                "validity_right": [0],
+                "combined_x_mm": [0.0],
+                "combined_y_mm": [0.0],
+                "combined_valid": [True],
+                "smoothed_x_mm": [0.0],
+                "smoothed_y_mm": [0.0],
+            }
+        ),
+        OlsenVelocityConfig(),
+    )
     assert calls == ["gap", "combined", "smooth"]
     assert result.at[0, "smooth"]
 


### PR DESCRIPTION
### Motivation

- Remove duplicated, slightly divergent logic for Tobii validity parsing and event reconstruction by centralizing domain rules to a single place. 
- Make pipeline-stage assumptions explicit and fail early with clear messages when required DataFrame columns are missing. 
- Keep the design lightweight and non-invasive: continue using `pandas`, avoid heavy schema libraries, and preserve backward-compatible aliases.

### Description

- Add a small `ivt_filter/domain` package with `validity.py` (`parse_tobii_validity`), `events.py` (contiguous-event iteration, `assign_event_indices`, and `rebuild_events_from_sample_labels`), and `schema.py` (central column-name constants and `require_columns`/`validate_*` helpers). 
- Replace duplicated `_parse_validity` implementations in `ivt_filter/preprocessing/gap_fill.py` and `ivt_filter/preprocessing/eye_selection.py` with the shared `parse_tobii_validity` (keeping a private alias `_parse_validity` for compatibility), and replace ad-hoc event-reconstruction logic in `ivt_filter/processing/classification.py` and `ivt_filter/postprocess.py` with `rebuild_events_from_sample_labels` and the contiguous-event iterator. 
- Add lightweight stage validation calls at pipeline boundaries: `prepare_velocity_input` now calls `validate_raw_gaze_frame` and `validate_preprocessed_frame`, `VelocitySampleComputer.compute` validates its input, and `IVTClassifier.classify` validates velocity input and validates classified output; all validators raise clear `ValueError` messages for missing columns. 
- Add tests in `tests/test_domain_rules.py` covering validity parsing, empty frames, missing required columns, single-sample events, Fixation/Saccade transitions, `Unclassified`/`EyesNotFound` behavior, and event-index resets, and adjust one preprocessing unit test to satisfy the explicit contracts in `schema.py`.

### Testing

- Ran `pytest -q` with the full test suite and got `196 passed, 1 skipped`. 
- Ran `ruff check ivt_filter` with no reportable issues. 
- Ran `mypy ivt_filter` with no type errors reported. 
- Exercised the new domain tests explicitly via `pytest tests/test_domain_rules.py` (included in the full run) and updated unit tests to respect the new stage contracts.
