### PR TITLE
Enable classification by default in compatibility IVTPipeline constructor

### DIFF
--- a/ivt_filter/io/pipeline.py
+++ b/ivt_filter/io/pipeline.py
@@ -71,7 +71,7 @@ class IVTPipeline:
             self.config = PipelineConfig(
                 velocity=velocity_config,
                 classifier=classifier_config,
-                classify=bool(saccade_merge_config or fixation_post_config),
+                classify=True,
                 saccade_merge=saccade_merge_config,
                 fixation_post=fixation_post_config,
             )

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -94,6 +94,41 @@ def test_run_and_run_with_tracking_use_equivalent_core_pipeline(
     assert stage_spy == ["velocity", "classify", "saccade", "fixation"] * 2
 
 
+def test_compatibility_constructor_enables_classification_without_postprocessing(
+    monkeypatch: pytest.MonkeyPatch,
+    stage_spy: list[str],
+) -> None:
+    monkeypatch.setattr("ivt_filter.io.pipeline.read_tsv", lambda path: pd.DataFrame({"time_ms": [0.0]}))
+    pipeline = IVTPipeline(OlsenVelocityConfig(), IVTClassifierConfig())
+
+    assert pipeline.config.classify is True
+
+    result = pipeline.run_with_tracking("input.tsv", SimpleNamespace(name="experiment"), evaluate=False)
+
+    assert stage_spy == ["velocity", "classify"]
+    assert "ivt_sample_type" in result.columns
+
+
+def test_explicit_pipeline_config_can_disable_classification(
+    monkeypatch: pytest.MonkeyPatch,
+    stage_spy: list[str],
+) -> None:
+    monkeypatch.setattr("ivt_filter.io.pipeline.read_tsv", lambda path: pd.DataFrame({"time_ms": [0.0]}))
+    pipeline = IVTPipeline(
+        PipelineConfig(
+            velocity=OlsenVelocityConfig(),
+            classifier=IVTClassifierConfig(),
+            classify=False,
+        )
+    )
+
+    result = pipeline.run_with_tracking("input.tsv", SimpleNamespace(name="experiment"), evaluate=False)
+
+    assert pipeline.config.classify is False
+    assert stage_spy == ["velocity"]
+    assert "ivt_sample_type" not in result.columns
+
+
 def test_legacy_run_flags_are_translated_into_pipeline_config(
     monkeypatch: pytest.MonkeyPatch,
     stage_spy: list[str],


### PR DESCRIPTION
### Motivation
- The compatibility constructor that accepts individual stage configs (`OlsenVelocityConfig`, `IVTClassifierConfig`) previously only enabled classification when post-processing configs were present, which caused silent skipping of classification for the common case of passing only velocity+classifier configs.
- The intent is to preserve direct `PipelineConfig(..., classify=False)` semantics while repairing the legacy adapter to behave as callers expect (classification enabled when a classifier is supplied).

### Description
- In `ivt_filter/io/pipeline.py` updated the compatibility branch of `IVTPipeline.__init__()` so the constructed `PipelineConfig` sets `classify=True` when called as `IVTPipeline(velocity_config, classifier_config)`.
- Added `tests/test_pipeline_config.py::test_compatibility_constructor_enables_classification_without_postprocessing` which monkeypatches `read_tsv` and stage functions, constructs `IVTPipeline(OlsenVelocityConfig(), IVTClassifierConfig())`, asserts `pipeline.config.classify is True`, runs `run_with_tracking(..., evaluate=False)`, and verifies classification executed and `ivt_sample_type` is present in the returned DataFrame.
- Added `tests/test_pipeline_config.py::test_explicit_pipeline_config_can_disable_classification` which verifies that an explicitly-constructed `PipelineConfig(..., classify=False)` still skips classification and does not produce `ivt_sample_type`.

### Testing
- Ran `pytest tests/test_pipeline_config.py` and the file-level regression tests passed (all tests in that file passed).
- Ran the full test suite with `pytest` and observed the suite completed successfully (197 passed, 2 skipped at time of run).
- Ran `git diff --check` to verify no whitespace errors were introduced and the repository reported a clean diff check.

