### PR TITLE
Deprecate incomplete parallel velocity compatibility wrapper

### DIFF
--- a/ivt_filter/processing/velocity_parallel.py
+++ b/ivt_filter/processing/velocity_parallel.py
@@ -1,213 +1,18 @@
-# ivt_filter/velocity_parallel.py
-"""
-Parallel velocity computation for large datasets.
+"""Compatibility wrappers for the canonical sequential velocity implementation.
 
-Uses joblib or multiprocessing to parallelize velocity calculations
-across multiple CPU cores for significant speedup on large datasets.
+This module previously reserved an API for parallel velocity calculation, but no
+parallel implementation was completed. Keep the public entry points for callers
+that imported them while delegating all calculations to ``compute_olsen_velocity``.
 """
 from __future__ import annotations
 
-from typing import Optional, Tuple, List
-import numpy as np
-import pandas as pd
-from dataclasses import dataclass
+import warnings
+from typing import Optional
 
-try:
-    from joblib import Parallel, delayed
-    JOBLIB_AVAILABLE = True
-except ImportError:
-    JOBLIB_AVAILABLE = False
-    Parallel = None
-    delayed = None
+import pandas as pd
 
 from ..config import OlsenVelocityConfig
-from .velocity import (
-    compute_olsen_velocity,
-    make_window_selector,
-    _get_coordinate_rounding_strategy,
-    _get_velocity_calculation_strategy,
-)
-from ..strategies import (
-    AsymmetricNeighborWindowSelector,
-)
-
-
-@dataclass
-class VelocityChunk:
-    """Data for a chunk of velocity calculations."""
-    indices: np.ndarray
-    times: np.ndarray
-    valid: np.ndarray
-    cx: np.ndarray
-    cy: np.ndarray
-    cz: np.ndarray
-    cex: np.ndarray
-    cey: np.ndarray
-    left_valid: np.ndarray
-    right_valid: np.ndarray
-    lx: np.ndarray
-    ly: np.ndarray
-    rx: np.ndarray
-    ry: np.ndarray
-    prev_invalid_idx: np.ndarray
-    next_invalid_idx: np.ndarray
-
-
-def _compute_velocity_for_chunk(
-    chunk: VelocityChunk,
-    cfg: OlsenVelocityConfig,
-    half_window: float,
-    gap_max: Optional[int],
-    hz_measured: Optional[float],
-    selector_type: str,
-    fallback_available: bool,
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Compute velocities for a chunk of samples.
-    
-    Returns:
-        Tuple of (velocities, window_widths, gap_triggered) arrays
-    """
-    n = len(chunk.indices)
-    velocities = np.full(n, np.nan, dtype=float)
-    window_widths = np.full(n, np.nan, dtype=float)
-    gap_triggered = np.zeros(n, dtype=bool)
-    
-    # Recreate selector and strategies (thread-safe)
-    selector = make_window_selector(cfg)
-    coord_rounding = _get_coordinate_rounding_strategy(cfg.coordinate_rounding)
-    velocity_strategy = _get_velocity_calculation_strategy(cfg.velocity_method)
-    
-    # Fallback selector if needed
-    from ..strategies import TimeSymmetricWindowSelector
-    fallback_selector = None
-    if fallback_available:
-        fallback_selector = TimeSymmetricWindowSelector()
-    
-    for idx, i in enumerate(chunk.indices):
-        # Check if sample is valid
-        if not chunk.valid[idx]:
-            continue
-        
-        # Select window
-        first_idx, last_idx = selector.select(
-            idx, chunk.times, chunk.valid, half_window
-        )
-        
-        # Fallback to time window if needed
-        if (first_idx is None or last_idx is None or first_idx == last_idx) and fallback_selector is not None:
-            first_idx_fb, last_idx_fb = fallback_selector.select(
-                idx, chunk.times, chunk.valid, half_window
-            )
-            if first_idx_fb is not None and last_idx_fb is not None and first_idx_fb != last_idx_fb:
-                first_idx, last_idx = first_idx_fb, last_idx_fb
-        
-        if first_idx is None or last_idx is None or first_idx == last_idx:
-            continue
-        
-        # Gap rule check
-        if gap_max is not None and gap_max >= 0:
-            L = int(chunk.prev_invalid_idx[idx])
-            R = int(chunk.next_invalid_idx[idx])
-            if L != -1 and R != -1 and L < i < R:
-                gap = R - L - 1
-                if gap <= gap_max:
-                    gap_triggered[idx] = True
-                    continue
-        
-        # Fallback for invalid first/last samples
-        if cfg.use_fallback_valid_samples:
-            if not chunk.valid[first_idx]:
-                for j in range(first_idx + 1, last_idx + 1):
-                    if chunk.valid[j]:
-                        first_idx = j
-                        break
-                else:
-                    continue
-            
-            if not chunk.valid[last_idx]:
-                for j in range(last_idx - 1, first_idx - 1, -1):
-                    if chunk.valid[j]:
-                        last_idx = j
-                        break
-                else:
-                    continue
-        
-        # Calculate time difference
-        if cfg.use_fixed_dt and isinstance(selector, AsymmetricNeighborWindowSelector):
-            if hz_measured is not None and hz_measured > 0:
-                dt_ms = 1000.0 / hz_measured
-            else:
-                dt_ms = float(chunk.times[last_idx] - chunk.times[first_idx])
-        else:
-            dt_ms = float(chunk.times[last_idx] - chunk.times[first_idx])
-        
-        if dt_ms < cfg.min_dt_ms:
-            continue
-        
-        # Get coordinates
-        x1, y1 = chunk.cx[first_idx], chunk.cy[first_idx]
-        x2, y2 = chunk.cx[last_idx], chunk.cy[last_idx]
-        
-        # Average mode strategies
-        if cfg.eye_mode == "average":
-            use_single_eye = cfg.average_window_single_eye
-            use_neighbor = cfg.average_window_impute_neighbor
-            
-            if use_single_eye or use_neighbor:
-                window_lv = chunk.left_valid[first_idx:last_idx + 1]
-                window_rv = chunk.right_valid[first_idx:last_idx + 1]
-                both_valid = window_lv & window_rv
-                single_valid = window_lv ^ window_rv
-                
-                if both_valid.any() and single_valid.any():
-                    if use_neighbor:
-                        # Impute with neighbor (simplified for parallel processing)
-                        pass  # Would need full implementation
-                    elif use_single_eye:
-                        candidates: List[Tuple[str, int]] = []
-                        if chunk.left_valid[first_idx] and chunk.left_valid[last_idx]:
-                            candidates.append(("left", int(window_lv.sum())))
-                        if chunk.right_valid[first_idx] and chunk.right_valid[last_idx]:
-                            candidates.append(("right", int(window_rv.sum())))
-                        if candidates:
-                            candidates.sort(key=lambda t: t[1], reverse=True)
-                            chosen_eye = candidates[0][0]
-                            if chosen_eye == "left":
-                                x1, y1 = chunk.lx[first_idx], chunk.ly[first_idx]
-                                x2, y2 = chunk.lx[last_idx], chunk.ly[last_idx]
-                            else:
-                                x1, y1 = chunk.rx[first_idx], chunk.ry[first_idx]
-                                x2, y2 = chunk.rx[last_idx], chunk.ry[last_idx]
-        
-        if any(pd.isna(v) for v in (x1, y1, x2, y2)):
-            continue
-        
-        # Apply coordinate rounding
-        x1, y1 = coord_rounding.round_gaze(x1, y1)
-        x2, y2 = coord_rounding.round_gaze(x2, y2)
-        
-        # Get eye position
-        eye_x = chunk.cex[idx] if idx < len(chunk.cex) else None
-        eye_y = chunk.cey[idx] if idx < len(chunk.cey) else None
-        eye_z = chunk.cz[idx] if idx < len(chunk.cz) else None
-        if eye_x is not None and eye_y is not None and eye_z is not None:
-            eye_x, eye_y, eye_z = coord_rounding.round_eye(eye_x, eye_y, eye_z)
-        
-        # Calculate velocity
-        angle_deg = velocity_strategy.calculate_visual_angle(
-            x1, y1, x2, y2, eye_x, eye_y, eye_z
-        )
-        dt_s = dt_ms / 1000.0
-        velocity = angle_deg / dt_s if dt_s > 0 else float("nan")
-        
-        if not pd.isna(velocity):
-            velocity = round(velocity, 1)
-        
-        velocities[idx] = velocity
-        window_widths[idx] = last_idx - first_idx + 1
-    
-    return velocities, window_widths, gap_triggered
+from .velocity import compute_olsen_velocity
 
 
 def compute_olsen_velocity_parallel(
@@ -216,97 +21,51 @@ def compute_olsen_velocity_parallel(
     n_jobs: int = -1,
     chunk_size: Optional[int] = None,
 ) -> pd.DataFrame:
-    """
-    Parallel version of compute_olsen_velocity.
-    
-    Splits the computation across multiple CPU cores for faster processing
-    on large datasets.
-    
+    """Deprecated compatibility wrapper around sequential ``compute_olsen_velocity``.
+
+    No parallel velocity implementation is active. The ``n_jobs`` and
+    ``chunk_size`` arguments are retained only for backwards compatibility and
+    do not change execution. Use :func:`compute_olsen_velocity` directly for new
+    code.
+
     Args:
-        df: Input DataFrame with eye tracking data
-        cfg: Velocity computation configuration
-        n_jobs: Number of parallel jobs (-1 = all CPUs, 1 = sequential)
-        chunk_size: Size of each chunk (None = auto-calculate)
-    
+        df: Input DataFrame with eye-tracking data.
+        cfg: Velocity-computation configuration.
+        n_jobs: Ignored compatibility argument.
+        chunk_size: Ignored compatibility argument.
+
     Returns:
-        DataFrame with velocity_deg_per_sec column added
-    
-    Example:
-        >>> from ivt_filter.velocity_parallel import compute_olsen_velocity_parallel
-        >>> from ivt_filter.config import OlsenVelocityConfig
-        >>> 
-        >>> cfg = OlsenVelocityConfig(window_length_ms=20.0)
-        >>> df = compute_olsen_velocity_parallel(df, cfg, n_jobs=-1)
-        >>> # Uses all CPU cores for faster processing
-    
-    Note:
-        - Requires joblib for parallel processing (pip install joblib)
-        - Falls back to sequential processing if joblib not available
-        - For small datasets (<10k samples), sequential may be faster due to overhead
-        - Recommended for datasets with >50k samples
+        The DataFrame returned by :func:`compute_olsen_velocity`.
     """
-    # Fall back to sequential if joblib not available or n_jobs=1
-    if not JOBLIB_AVAILABLE or n_jobs == 1:
-        if not JOBLIB_AVAILABLE:
-            print("[Parallel] joblib not available, falling back to sequential processing")
-        return compute_olsen_velocity(df, cfg)
-    
-    print(f"[Parallel] Using parallel velocity computation with n_jobs={n_jobs}")
-    
-    # Use the sequential version for preprocessing
-    # (gap filling, smoothing, selector setup, etc.)
-    # This is a simplified approach - in production you might want to
-    # refactor compute_olsen_velocity to separate preprocessing from computation
-    
-    # For now, fall back to sequential
-    # TODO: Full parallel implementation would require refactoring compute_olsen_velocity
-    print("[Parallel] Full parallel implementation not yet available, using sequential")
+    warnings.warn(
+        "compute_olsen_velocity_parallel() is deprecated; use "
+        "compute_olsen_velocity(). Velocity computation is sequential.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return compute_olsen_velocity(df, cfg)
 
 
-def estimate_optimal_chunk_size(n_samples: int, n_jobs: int) -> int:
-    """
-    Estimate optimal chunk size for parallel processing.
-    
-    Args:
-        n_samples: Total number of samples
-        n_jobs: Number of parallel jobs
-    
-    Returns:
-        Optimal chunk size
-    """
-    if n_jobs == -1:
-        import os
-        n_jobs = os.cpu_count() or 1
-    
-    # Aim for ~10 chunks per job for good load balancing
-    target_chunks = n_jobs * 10
-    chunk_size = max(1000, n_samples // target_chunks)
-    
-    return chunk_size
-
-
-# Convenience function for easy switching
 def compute_velocity_auto(
     df: pd.DataFrame,
     cfg: OlsenVelocityConfig,
     parallel: bool = True,
     n_jobs: int = -1,
 ) -> pd.DataFrame:
-    """
-    Automatically choose between parallel and sequential computation.
-    
+    """Compatibility wrapper around sequential ``compute_olsen_velocity``.
+
+    This function does not select a parallel implementation, regardless of the
+    DataFrame size. The ``parallel`` and ``n_jobs`` arguments are retained only
+    for backwards compatibility and do not change execution. Use
+    :func:`compute_olsen_velocity` directly for new code.
+
     Args:
-        df: Input DataFrame
-        cfg: Velocity configuration
-        parallel: Whether to attempt parallel processing
-        n_jobs: Number of parallel jobs (-1 = all CPUs)
-    
+        df: Input DataFrame with eye-tracking data.
+        cfg: Velocity-computation configuration.
+        parallel: Ignored compatibility argument.
+        n_jobs: Ignored compatibility argument.
+
     Returns:
-        DataFrame with velocity computed
+        The DataFrame returned by :func:`compute_olsen_velocity`.
     """
-    # Use parallel for large datasets (>50k samples)
-    if parallel and len(df) > 50000 and JOBLIB_AVAILABLE:
-        return compute_olsen_velocity_parallel(df, cfg, n_jobs=n_jobs)
-    else:
-        return compute_olsen_velocity(df, cfg)
+    return compute_olsen_velocity(df, cfg)

--- a/tests/test_velocity_parallel_compat.py
+++ b/tests/test_velocity_parallel_compat.py
@@ -1,0 +1,46 @@
+import pandas as pd
+import pytest
+
+from ivt_filter.config import OlsenVelocityConfig
+from ivt_filter.processing import velocity_parallel
+
+
+def test_compute_olsen_velocity_parallel_delegates_to_canonical_implementation(
+    monkeypatch,
+):
+    df = pd.DataFrame({"sample": [1]})
+    cfg = OlsenVelocityConfig()
+    expected = pd.DataFrame({"velocity_deg_per_sec": [12.3]})
+    calls = []
+
+    def canonical(received_df, received_cfg):
+        calls.append((received_df, received_cfg))
+        return expected
+
+    monkeypatch.setattr(velocity_parallel, "compute_olsen_velocity", canonical)
+
+    with pytest.warns(DeprecationWarning, match="Velocity computation is sequential"):
+        result = velocity_parallel.compute_olsen_velocity_parallel(
+            df, cfg, n_jobs=8, chunk_size=1000
+        )
+
+    assert result is expected
+    assert calls == [(df, cfg)]
+
+
+def test_compute_velocity_auto_delegates_to_canonical_implementation(monkeypatch):
+    df = pd.DataFrame({"sample": range(50_001)})
+    cfg = OlsenVelocityConfig()
+    expected = pd.DataFrame({"velocity_deg_per_sec": [45.6]})
+    calls = []
+
+    def canonical(received_df, received_cfg):
+        calls.append((received_df, received_cfg))
+        return expected
+
+    monkeypatch.setattr(velocity_parallel, "compute_olsen_velocity", canonical)
+
+    result = velocity_parallel.compute_velocity_auto(df, cfg, parallel=True, n_jobs=8)
+
+    assert result is expected
+    assert calls == [(df, cfg)]


### PR DESCRIPTION
### Motivation
- The module previously advertised a parallel velocity implementation that was never completed and contained unused chunking and `joblib`-related code that could mislead callers. 
- Preserve backward compatibility for callers that import the parallel API while making it explicit that computation is sequential. 
- Add focused delegation tests to guarantee that the public compatibility functions call the canonical sequential implementation.

### Description
- Replace the previous pseudo-parallel implementation with thin compatibility wrappers that delegate to `compute_olsen_velocity` and clearly document the deprecation. 
- Deprecate `compute_olsen_velocity_parallel()` so it emits a `DeprecationWarning` and documents that `n_jobs` and `chunk_size` are ignored compatibility arguments. 
- Update `compute_velocity_auto()` to always delegate to `compute_olsen_velocity()` and stop implying that large DataFrames receive parallel acceleration. 
- Remove the unused chunk-processing machinery and `joblib`-availability logic, and add `tests/test_velocity_parallel_compat.py` which monkeypatches `compute_olsen_velocity()` to verify delegation and the deprecation warning.

### Testing
- Ran the new focused tests with `pytest -q tests/test_velocity_parallel_compat.py`, and they passed. 
- Ran the full test suite with `pytest -q`, which completed successfully with `199 passed, 2 skipped`. 
- Verified that the compatibility wrappers behave as intended by asserting the monkeypatched `compute_olsen_velocity()` received the original arguments and its return value was forwarded.

