### PR TITLE
Validate incompatible Olsen velocity window selector modes

### DIFF
--- a/ivt_filter/config/config.py
+++ b/ivt_filter/config/config.py
@@ -205,6 +205,65 @@ class OlsenVelocityConfig:
     # Entspricht: RemoteTrackerGazeDataToRecordedTwoEyedGazeDataConverter (Tobii C#)
     tobii_eye_offset_interpolation: bool = False
 
+    def __post_init__(self) -> None:
+        """Reject window-selector settings hidden by the legacy precedence rules."""
+        # Keep this validation aligned with processing.velocity.make_window_selector().
+        # A later compatibility-preserving migration can translate these legacy
+        # booleans into one explicit window-policy type at the config boundary.
+        fixed_window_modes: list[str] = []
+        if self.fixed_window_samples is not None:
+            fixed_window_modes.append("fixed_window_samples")
+        if self.auto_fixed_window_from_ms:
+            fixed_window_modes.append("auto_fixed_window_from_ms")
+        if self.symmetric_round_window:
+            fixed_window_modes.append("symmetric_round_window")
+
+        non_tobii_selector_modes: list[str] = []
+        if self.asymmetric_neighbor_window:
+            non_tobii_selector_modes.append("asymmetric_neighbor_window")
+        if self.shifted_valid_window:
+            non_tobii_selector_modes.append("shifted_valid_window")
+        non_tobii_selector_modes.extend(fixed_window_modes)
+        if self.sample_symmetric_window:
+            non_tobii_selector_modes.append("sample_symmetric_window")
+
+        if self.tobii_window_mode and non_tobii_selector_modes:
+            self._raise_window_selector_conflict(
+                "tobii_window_mode", non_tobii_selector_modes
+            )
+
+        asymmetric_conflicts: list[str] = []
+        if self.shifted_valid_window:
+            asymmetric_conflicts.append("shifted_valid_window")
+        asymmetric_conflicts.extend(fixed_window_modes)
+        if self.sample_symmetric_window:
+            asymmetric_conflicts.append("sample_symmetric_window")
+        if self.asymmetric_neighbor_window and asymmetric_conflicts:
+            self._raise_window_selector_conflict(
+                "asymmetric_neighbor_window", asymmetric_conflicts
+            )
+
+        if self.shifted_valid_window and self.sample_symmetric_window:
+            self._raise_window_selector_conflict(
+                "shifted_valid_window", ["sample_symmetric_window"]
+            )
+
+        if fixed_window_modes and self.sample_symmetric_window:
+            self._raise_window_selector_conflict(
+                fixed_window_modes[0], ["sample_symmetric_window"]
+            )
+
+    @staticmethod
+    def _raise_window_selector_conflict(
+        selected_mode: str, ignored_modes: list[str]
+    ) -> None:
+        ignored = ", ".join(ignored_modes)
+        raise ValueError(
+            "Window selector configuration is ambiguous: "
+            f"{selected_mode} takes precedence over {ignored}; "
+            "configure only one active selector mode."
+        )
+
 
 @dataclass
 class IVTClassifierConfig:

--- a/tests/test_velocity_config_validation.py
+++ b/tests/test_velocity_config_validation.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import pytest
+
+from ivt_filter.config import OlsenVelocityConfig
+
+
+@pytest.mark.parametrize(
+    "selector_mode",
+    [
+        {"asymmetric_neighbor_window": True},
+        {"shifted_valid_window": True},
+        {"fixed_window_samples": 5},
+        {"auto_fixed_window_from_ms": True},
+        {"symmetric_round_window": True},
+        {"sample_symmetric_window": True},
+    ],
+)
+def test_tobii_window_mode_rejects_non_tobii_selector_modes(
+    selector_mode: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="tobii_window_mode takes precedence"):
+        OlsenVelocityConfig(tobii_window_mode=True, **selector_mode)
+
+
+@pytest.mark.parametrize(
+    "selector_mode",
+    [
+        {"fixed_window_samples": 5},
+        {"auto_fixed_window_from_ms": True},
+        {"symmetric_round_window": True},
+        {"shifted_valid_window": True},
+        {"sample_symmetric_window": True},
+    ],
+)
+def test_asymmetric_neighbor_window_rejects_shadowed_selector_modes(
+    selector_mode: dict[str, object],
+) -> None:
+    with pytest.raises(
+        ValueError, match="asymmetric_neighbor_window takes precedence"
+    ):
+        OlsenVelocityConfig(asymmetric_neighbor_window=True, **selector_mode)
+
+
+@pytest.mark.parametrize(
+    "selector_mode",
+    [
+        {"sample_symmetric_window": True},
+        {"asymmetric_neighbor_window": True},
+        {"tobii_window_mode": True},
+    ],
+)
+def test_shifted_valid_window_rejects_incompatible_selector_flags(
+    selector_mode: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="takes precedence"):
+        OlsenVelocityConfig(shifted_valid_window=True, **selector_mode)
+
+
+@pytest.mark.parametrize(
+    "fixed_window_mode",
+    [
+        {"fixed_window_samples": 5},
+        {"auto_fixed_window_from_ms": True},
+        {"symmetric_round_window": True},
+    ],
+)
+def test_fixed_window_modes_reject_sample_symmetric_window(
+    fixed_window_mode: dict[str, object],
+) -> None:
+    with pytest.raises(
+        ValueError, match="takes precedence over sample_symmetric_window"
+    ):
+        OlsenVelocityConfig(sample_symmetric_window=True, **fixed_window_mode)
+
+
+@pytest.mark.parametrize(
+    "fixed_window_mode",
+    [
+        {"fixed_window_samples": 5},
+        {"auto_fixed_window_from_ms": True},
+        {"symmetric_round_window": True},
+    ],
+)
+def test_shifted_valid_window_accepts_compatible_fixed_window_modes(
+    fixed_window_mode: dict[str, object],
+) -> None:
+    cfg = OlsenVelocityConfig(shifted_valid_window=True, **fixed_window_mode)
+    assert cfg.shifted_valid_window is True


### PR DESCRIPTION
### Motivation

- Prevent ambiguous or contradictory legacy boolean flags in `OlsenVelocityConfig` that would be silently shadowed by higher-priority selector modes at runtime.  
- Keep configuration errors discoverable early rather than letting `make_window_selector()` hide user intent.  
- Preserve numerical behavior and allow a future, compatibility-preserving migration to a single explicit window-policy type translated from legacy booleans.

### Description

- Add `OlsenVelocityConfig.__post_init__()` which validates combinations of window-selector flags and rejects configurations that would be ambiguous given the precedence in `processing.velocity.make_window_selector()` (e.g. `tobii_window_mode` vs non-Tobii selectors, `asymmetric_neighbor_window` vs fixed/shifted modes, `shifted_valid_window` vs sample-symmetric).  
- Implement `_raise_window_selector_conflict()` helper to surface a concise `ValueError` explaining which higher-priority mode takes precedence over which ignored modes.  
- Add parametrized tests in `tests/test_velocity_config_validation.py` that cover conflicting combinations and one positive case where `shifted_valid_window` stays compatible with fixed-window modes.  
- Do not change selector implementation or any numeric behavior; validation only rejects ambiguous configs at construction time and documents a migration path toward an explicit window-policy boundary.

### Testing

- Ran the new targeted tests with `pytest tests/test_velocity_config_validation.py` and they passed.  
- Ran a selection of related tests `pytest tests/test_velocity_processing_components.py tests/test_velocity_endpoint_metadata.py tests/test_tobii_compat.py` and they passed.  
- Ran the full test suite with `pytest` (project tests) and verification steps (`python -m compileall -q ivt_filter tests`, `git diff --check`); test run completed successfully with the suite result: 219 passed, 2 skipped.

