### PR TITLE
Tighten common IVTPipeline tracking smoke test

### DIFF
--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -112,6 +112,7 @@ def test_common_example_tracking_flow_returns_velocity_and_classification_column
     result = pipeline.run_with_tracking("input.tsv", SimpleNamespace(name="experiment"), evaluate=False)
 
     assert {"velocity_deg_per_sec", "ivt_sample_type"} <= set(result.columns)
+    assert list(result.columns) == ["time_ms", "velocity_deg_per_sec", "ivt_sample_type"]
 
 
 def test_explicit_pipeline_config_can_disable_classification(


### PR DESCRIPTION
### Motivation
- Ensure the deterministic smoke test for the common `IVTPipeline` example verifies the exact minimal output schema to catch regressions in output structure.

### Description
- Strengthen `tests/test_pipeline_config.py::test_common_example_tracking_flow_returns_velocity_and_classification_columns` to additionally assert the ordered output columns are exactly `["time_ms", "velocity_deg_per_sec", "ivt_sample_type"]` while retaining the previous presence check for `velocity_deg_per_sec` and `ivt_sample_type`.

### Testing
- Ran `pytest tests/test_pipeline_config.py tests/test_public_api.py` which passed; also ran the full test suite with `pytest` which passed (all tests green).

