### PR TITLE
Clarify sequential-only velocity compatibility wrappers and add delegation tests

### DIFF
--- a/ivt_filter/processing/velocity_parallel.py
+++ b/ivt_filter/processing/velocity_parallel.py
@@ -14,6 +14,8 @@ import pandas as pd
 from ..config import OlsenVelocityConfig
 from .velocity import compute_olsen_velocity
 
+__all__ = ["compute_olsen_velocity_parallel", "compute_velocity_auto"]
+
 
 def compute_olsen_velocity_parallel(
     df: pd.DataFrame,

--- a/tests/test_velocity_parallel_compat.py
+++ b/tests/test_velocity_parallel_compat.py
@@ -28,8 +28,12 @@ def test_compute_olsen_velocity_parallel_delegates_to_canonical_implementation(
     assert calls == [(df, cfg)]
 
 
-def test_compute_velocity_auto_delegates_to_canonical_implementation(monkeypatch):
-    df = pd.DataFrame({"sample": range(50_001)})
+@pytest.mark.parametrize("sample_count", [1, 50_001])
+@pytest.mark.parametrize("parallel", [False, True])
+def test_compute_velocity_auto_delegates_to_canonical_implementation(
+    monkeypatch, sample_count, parallel
+):
+    df = pd.DataFrame({"sample": range(sample_count)})
     cfg = OlsenVelocityConfig()
     expected = pd.DataFrame({"velocity_deg_per_sec": [45.6]})
     calls = []
@@ -40,7 +44,7 @@ def test_compute_velocity_auto_delegates_to_canonical_implementation(monkeypatch
 
     monkeypatch.setattr(velocity_parallel, "compute_olsen_velocity", canonical)
 
-    result = velocity_parallel.compute_velocity_auto(df, cfg, parallel=True, n_jobs=8)
+    result = velocity_parallel.compute_velocity_auto(df, cfg, parallel=parallel, n_jobs=8)
 
     assert result is expected
     assert calls == [(df, cfg)]


### PR DESCRIPTION
### Motivation
- The module previously exposed a parallel API surface without a working parallel backend, which risked misleading callers into expecting parallel acceleration; the change makes the wrappers explicit compatibility shims delegating to the canonical sequential implementation.

### Description
- Make `compute_olsen_velocity_parallel()` a deprecated compatibility wrapper that emits a `DeprecationWarning`, documents that `n_jobs`/`chunk_size` are ignored, and delegates to `compute_olsen_velocity()`.
- Make `compute_velocity_auto()` an explicit sequential compatibility wrapper whose `parallel`/`n_jobs` arguments are documented as ignored and which delegates to `compute_olsen_velocity()`.
- Restrict the module public surface by adding `__all__ = ["compute_olsen_velocity_parallel", "compute_velocity_auto"]`.
- Add and harden tests in `tests/test_velocity_parallel_compat.py` that monkeypatch `compute_olsen_velocity()` and verify both `compute_olsen_velocity_parallel()` and `compute_velocity_auto()` delegate to the canonical implementation, with `compute_velocity_auto()` parametrized for small/large inputs and both values of the legacy `parallel` flag.

### Testing
- Ran `pytest -q tests/test_velocity_parallel_compat.py` and the targeted compatibility tests passed (`5 passed`).
- Ran the full test suite with `pytest -q` and all tests passed (`222 passed, 2 skipped`).
- Ran style/type checks with `ruff` and `mypy` (`mypy ivt_filter` reported no issues) and they succeeded.
