### PR TITLE
Clarify Olsen velocity window compatibility validation boundary

### DIFF
--- a/ivt_filter/config/config.py
+++ b/ivt_filter/config/config.py
@@ -34,7 +34,7 @@ Beispiel:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Literal, Optional, Sequence
 
 
 @dataclass
@@ -207,25 +207,14 @@ class OlsenVelocityConfig:
 
     def __post_init__(self) -> None:
         """Reject window-selector settings hidden by the legacy precedence rules."""
-        # Keep this validation aligned with processing.velocity.make_window_selector().
-        # A later compatibility-preserving migration can translate these legacy
-        # booleans into one explicit window-policy type at the config boundary.
-        fixed_window_modes: list[str] = []
-        if self.fixed_window_samples is not None:
-            fixed_window_modes.append("fixed_window_samples")
-        if self.auto_fixed_window_from_ms:
-            fixed_window_modes.append("auto_fixed_window_from_ms")
-        if self.symmetric_round_window:
-            fixed_window_modes.append("symmetric_round_window")
-
-        non_tobii_selector_modes: list[str] = []
-        if self.asymmetric_neighbor_window:
-            non_tobii_selector_modes.append("asymmetric_neighbor_window")
-        if self.shifted_valid_window:
-            non_tobii_selector_modes.append("shifted_valid_window")
-        non_tobii_selector_modes.extend(fixed_window_modes)
-        if self.sample_symmetric_window:
-            non_tobii_selector_modes.append("sample_symmetric_window")
+        # Keep this boundary validation aligned with
+        # processing.velocity.make_window_selector(). A later compatibility-
+        # preserving migration can translate these legacy booleans into one
+        # explicit window-policy type here without changing selector behavior.
+        fixed_window_modes = self._active_fixed_window_modes()
+        non_tobii_selector_modes = self._active_non_tobii_window_modes(
+            fixed_window_modes
+        )
 
         if self.tobii_window_mode and non_tobii_selector_modes:
             self._raise_window_selector_conflict(
@@ -253,9 +242,34 @@ class OlsenVelocityConfig:
                 fixed_window_modes[0], ["sample_symmetric_window"]
             )
 
+    def _active_fixed_window_modes(self) -> list[str]:
+        """Return legacy settings that activate or derive a fixed sample window."""
+        modes: list[str] = []
+        if self.fixed_window_samples is not None:
+            modes.append("fixed_window_samples")
+        if self.auto_fixed_window_from_ms:
+            modes.append("auto_fixed_window_from_ms")
+        if self.symmetric_round_window:
+            modes.append("symmetric_round_window")
+        return modes
+
+    def _active_non_tobii_window_modes(
+        self, fixed_window_modes: Sequence[str]
+    ) -> list[str]:
+        """Return selector settings hidden when Tobii window mode is active."""
+        modes: list[str] = []
+        if self.asymmetric_neighbor_window:
+            modes.append("asymmetric_neighbor_window")
+        if self.shifted_valid_window:
+            modes.append("shifted_valid_window")
+        modes.extend(fixed_window_modes)
+        if self.sample_symmetric_window:
+            modes.append("sample_symmetric_window")
+        return modes
+
     @staticmethod
     def _raise_window_selector_conflict(
-        selected_mode: str, ignored_modes: list[str]
+        selected_mode: str, ignored_modes: Sequence[str]
     ) -> None:
         ignored = ", ".join(ignored_modes)
         raise ValueError(

--- a/tests/test_velocity_config_validation.py
+++ b/tests/test_velocity_config_validation.py
@@ -87,3 +87,27 @@ def test_shifted_valid_window_accepts_compatible_fixed_window_modes(
 ) -> None:
     cfg = OlsenVelocityConfig(shifted_valid_window=True, **fixed_window_mode)
     assert cfg.shifted_valid_window is True
+
+
+@pytest.mark.parametrize(
+    ("config_kwargs", "selector_type"),
+    [
+        ({}, "TimeSymmetricWindowSelector"),
+        ({"sample_symmetric_window": True}, "SampleSymmetricWindowSelector"),
+        ({"fixed_window_samples": 5}, "FixedSampleSymmetricWindowSelector"),
+        ({"shifted_valid_window": True}, "TimeBasedShiftedValidWindowSelector"),
+        (
+            {"shifted_valid_window": True, "fixed_window_samples": 5},
+            "ShiftedValidWindowSelector",
+        ),
+        ({"asymmetric_neighbor_window": True}, "AsymmetricNeighborWindowSelector"),
+    ],
+)
+def test_compatible_legacy_window_modes_keep_existing_selector_behavior(
+    config_kwargs: dict[str, object], selector_type: str
+) -> None:
+    from ivt_filter.processing.velocity import make_window_selector
+
+    selector = make_window_selector(OlsenVelocityConfig(**config_kwargs))
+
+    assert type(selector).__name__ == selector_type


### PR DESCRIPTION
### Motivation

- Prevent ambiguous combinations of legacy window-selection booleans by validating incompatible OlsenVelocityConfig flags at the configuration boundary according to the selector precedence used in `make_window_selector()`.
- Establish a clear, compatibility-preserving place to later translate legacy booleans into a single explicit window-policy type without changing runtime numerical behavior.

### Description

- Tighten `OlsenVelocityConfig.__post_init__()` by delegating legacy-mode discovery to two helpers, `._active_fixed_window_modes()` and `._active_non_tobii_window_modes()`, and keep validation aligned with `make_window_selector()` behavior.
- Add the helper methods `._active_fixed_window_modes()` and `._active_non_tobii_window_modes()` and refine the `_raise_window_selector_conflict()` signature to accept a `Sequence[str]` for clearer typing and reuse.
- Import `Sequence` in the config typing imports to support the new helper signatures.
- Add parametrized regression tests in `tests/test_velocity_config_validation.py` that (a) continue to cover conflicting combinations (Tobii vs non-Tobii, asymmetric neighbor vs fixed/shifted, shifted_valid vs incompatible flags) and (b) assert that compatible legacy configurations still resolve to the same selector classes returned by `make_window_selector()`.

### Testing

- Ran the focused validation tests with `pytest -q tests/test_velocity_config_validation.py` and they passed.
- Ran the full test suite with `pytest -q` and it completed successfully (all tests passed except the configured skips).
