### PR TITLE
Configurable gap velocity cap for fixation merge (max_gap_velocity_deg_per_sec)

### DIFF
--- a/ivt_filter/cli.py
+++ b/ivt_filter/cli.py
@@ -456,6 +456,12 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Maximaler visueller Winkel in Grad zwischen Fixationszentren fuer Merge (default: 0.5).",
     )
     parser.add_argument(
+        "--merge-fix-max-gap-velocity-deg-per-sec",
+        type=float,
+        default=35.0,
+        help="Maximale Velocity in Grad/s fuer das Relabeling von Gap-Samples (default: 35).",
+    )
+    parser.add_argument(
         "--discard-short-fixations",
         action="store_true",
         help="Fixationen verwerfen, deren Dauer kleiner als min-fixation-duration-ms ist.",

--- a/ivt_filter/config/config.py
+++ b/ivt_filter/config/config.py
@@ -342,6 +342,7 @@ class FixationPostConfig:
     merge_adjacent_fixations: bool = False
     max_time_gap_ms: float = 75.0   # z.B. 75 ms wie im Tobii-Paper
     max_angle_deg: float = 0.5      # z.B. 0.5 Grad zwischen Fixationszentren
+    max_gap_velocity_deg_per_sec: float = 35.0  # maximale Velocity fuer Gap-Relabeling
 
     # Gewichtungsstrategie für gemittelte Fixations-Position beim Merge:
     # - "uniform": np.nanmean aller Samples (bisheriges Verhalten)

--- a/ivt_filter/config/config_builder.py
+++ b/ivt_filter/config/config_builder.py
@@ -98,6 +98,7 @@ class ConfigBuilder:
             min_fixation_duration_ms=args.min_fixation_duration_ms,
             max_time_gap_ms=args.merge_fix_max_gap_ms,
             max_angle_deg=args.merge_fix_max_angle_deg,
+            max_gap_velocity_deg_per_sec=args.merge_fix_max_gap_velocity_deg_per_sec,
             merge_adjacent_fixations=args.merge_close_fixations,
             discard_short_fixations=args.discard_short_fixations,
             discard_target=args.discard_fixation_target,

--- a/ivt_filter/postprocessing/merge_fixations.py
+++ b/ivt_filter/postprocessing/merge_fixations.py
@@ -192,11 +192,10 @@ def merge_adjacent_fixations(
                     continue
                 
                 # Velocity-basiertes Gap-Filling:
-                # Nur Samples mit niedriger Velocity (<= 35°/s) werden gemerged
-                # Rational: IVT-Threshold ist 30°/s, +5°/s Puffer für Grenzfälle
-                # Verhindert echte Saccade-Samples (> 35°/s) in Fixations
+                # Nur Samples bis zum konfigurierten Velocity-Cap werden gemerged.
+                # Verhindert echte Saccade-Samples in Fixations.
                 if velocity is not None and not pd.isna(velocity[j]):
-                    if velocity[j] > 35.0:
+                    if velocity[j] > cfg.max_gap_velocity_deg_per_sec:
                         continue
                 
                 labels[j] = "Fixation"

--- a/tests/test_tobii_compat.py
+++ b/tests/test_tobii_compat.py
@@ -634,6 +634,103 @@ class TestMergeFixationsSampleCountWeighting:
         assert cfg.merge_weighting == "sample_count"
 
 
+class TestMergeFixationsGapVelocityCap:
+    """Regressionstests fuer den konfigurierbaren Velocity-Cap beim Gap-Relabeling."""
+
+    @staticmethod
+    def _merge_gap_velocities(
+        gap_velocities: list[float],
+        *,
+        max_gap_velocity_deg_per_sec: float = 35.0,
+    ) -> tuple[pd.DataFrame, dict[str, object], slice]:
+        gap = len(gap_velocities)
+        fixation_len = 3
+        n = fixation_len + gap + fixation_len
+        gap_slice = slice(fixation_len, fixation_len + gap)
+        df = pd.DataFrame({
+            "time_ms": np.arange(n, dtype=float),
+            "combined_x_mm": np.zeros(n),
+            "combined_y_mm": np.zeros(n),
+            "eye_z_mm": np.full(n, 600.0),
+            "ivt_sample_type": (
+                ["Fixation"] * fixation_len
+                + ["Unclassified"] * gap
+                + ["Fixation"] * fixation_len
+            ),
+            "velocity_deg_per_sec": (
+                [0.0] * fixation_len
+                + gap_velocities
+                + [0.0] * fixation_len
+            ),
+        })
+        cfg = FixationPostConfig(
+            merge_adjacent_fixations=True,
+            max_time_gap_ms=10.0,
+            max_angle_deg=0.5,
+            max_gap_velocity_deg_per_sec=max_gap_velocity_deg_per_sec,
+        )
+        result, stats = merge_adjacent_fixations(
+            df, cfg,
+            sample_col="ivt_sample_type",
+            time_col="time_ms",
+            x_col="combined_x_mm",
+            y_col="combined_y_mm",
+            eye_z_col="eye_z_mm",
+        )
+        return result, stats, gap_slice
+
+    def test_sample_at_configured_cap_is_eligible_for_relabeling(self):
+        """Der Cap ist inklusiv: Velocity == Cap darf zur Fixation werden."""
+        result, stats, gap_slice = self._merge_gap_velocities(
+            [12.0], max_gap_velocity_deg_per_sec=12.0
+        )
+
+        assert result.iloc[gap_slice]["ivt_sample_type"].tolist() == ["Fixation"]
+        assert stats["gap_samples_to_fixation"] == 1
+
+    def test_sample_above_configured_cap_is_preserved(self):
+        """Velocity > Cap behaelt das urspruengliche Gap-Label."""
+        result, stats, gap_slice = self._merge_gap_velocities(
+            [12.01], max_gap_velocity_deg_per_sec=12.0
+        )
+
+        assert result.iloc[gap_slice]["ivt_sample_type"].tolist() == ["Unclassified"]
+        assert stats["gap_samples_to_fixation"] == 0
+
+    def test_default_cap_preserves_existing_35_deg_per_sec_behavior(self):
+        """Der neue Config-Default entspricht der bisherigen festen 35-Grad-Grenze."""
+        assert FixationPostConfig().max_gap_velocity_deg_per_sec == 35.0
+
+        result, stats, gap_slice = self._merge_gap_velocities([35.0, 35.01])
+
+        assert result.iloc[gap_slice]["ivt_sample_type"].tolist() == [
+            "Fixation",
+            "Unclassified",
+        ]
+        assert stats["gap_samples_to_fixation"] == 1
+
+    def test_custom_cap_changes_only_intended_gap_fill_decision(self):
+        """Ein eigener Cap relabelt nur das zusaetzlich berechtigte Gap-Sample."""
+        default_result, _, gap_slice = self._merge_gap_velocities([34.0, 36.0, 37.0])
+        custom_result, _, _ = self._merge_gap_velocities(
+            [34.0, 36.0, 37.0], max_gap_velocity_deg_per_sec=36.0
+        )
+
+        assert default_result.iloc[gap_slice]["ivt_sample_type"].tolist() == [
+            "Fixation",
+            "Unclassified",
+            "Unclassified",
+        ]
+        assert custom_result.iloc[gap_slice]["ivt_sample_type"].tolist() == [
+            "Fixation",
+            "Fixation",
+            "Unclassified",
+        ]
+        assert custom_result.loc[[0, 1, 2, 6, 7, 8], "ivt_sample_type"].tolist() == [
+            "Fixation",
+        ] * 6
+
+
 # ---------------------------------------------------------------------------
 # 5. Integration: OlsenVelocityConfig mit Tobii-Flags
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Provide a configurable, independent cap for velocity-based gap relabeling during fixation merging to avoid hard-coded literals and allow experimental control.  
- Preserve existing behavior by default (35.0 deg/s) while keeping this post-processing parameter separate from the classifier threshold.

### Description

- Add `max_gap_velocity_deg_per_sec: float = 35.0` to `FixationPostConfig` as `FixationPostConfig.max_gap_velocity_deg_per_sec` to control gap relabeling.  
- Replace the hard-coded `35.0` literal in `merge_adjacent_fixations()` with `cfg.max_gap_velocity_deg_per_sec` so gap samples are skipped when `velocity > cfg.max_gap_velocity_deg_per_sec`.  
- Expose the new option on the CLI as `--merge-fix-max-gap-velocity-deg-per-sec` and thread it through `ConfigBuilder.build_fixation_post_config()` so CLI-driven configs populate the new field.  
- Add regression tests (`TestMergeFixationsGapVelocityCap` in `tests/test_tobii_compat.py`) that verify inclusion at the boundary, preservation above the cap, default behavior matching the previous 35.0 cutoff, and that a custom cap only changes the intended decisions.

### Testing

- Ran the targeted tests: `pytest -q tests/test_tobii_compat.py` (passed).  
- Ran full test suite: `pytest -q` which completed with `226 passed, 2 skipped`.  
- Verified CLI-to-config propagation with `build_arg_parser` and `ConfigBuilder.build_fixation_post_config` using `--merge-fix-max-gap-velocity-deg-per-sec` (assertion succeeded).  
- Verified bytecode compilation via `python -m compileall -q ivt_filter tests` and `git diff --check` for whitespace errors (no issues).
