### PR TITLE
Migrate internal diagnostic prints to structured logging

### DIFF
--- a/ivt_filter/io/pipeline.py
+++ b/ivt_filter/io/pipeline.py
@@ -6,6 +6,7 @@ Implements Observer Pattern for automatic experiment tracking.
 """
 from __future__ import annotations
 
+import logging
 from typing import Optional, List, Dict, Any
 
 import pandas as pd
@@ -23,6 +24,8 @@ from ..processing.velocity import compute_olsen_velocity
 from ..processing.classification import apply_ivt_classifier, expand_gt_events_to_samples
 from ..postprocess import merge_short_saccade_blocks, apply_fixation_postprocessing
 from ..evaluation.evaluation import evaluate_ivt_vs_ground_truth, compute_ivt_metrics
+
+logger = logging.getLogger(__name__)
 
 
 class IVTPipeline:
@@ -119,7 +122,7 @@ class IVTPipeline:
             try:
                 observer.on_pipeline_start(config)
             except Exception as e:
-                print(f"Warning: Observer {type(observer).__name__} failed on start: {e}")
+                logger.warning("Observer %s failed on start: %s", type(observer).__name__, e)
     
     def _notify_complete(
         self,
@@ -132,7 +135,7 @@ class IVTPipeline:
             try:
                 observer.on_pipeline_complete(config, results_df, metrics)
             except Exception as e:
-                print(f"Warning: Observer {type(observer).__name__} failed on complete: {e}")
+                logger.warning("Observer %s failed on complete: %s", type(observer).__name__, e)
     
     def _notify_error(self, config: Any, error: Exception) -> None:
         """Notify all observers that pipeline encountered an error."""
@@ -140,7 +143,7 @@ class IVTPipeline:
             try:
                 observer.on_pipeline_error(config, error)
             except Exception as e:
-                print(f"Warning: Observer {type(observer).__name__} failed on error: {e}")
+                logger.warning("Observer %s failed on error: %s", type(observer).__name__, e)
     
     def run_with_tracking(
         self,
@@ -196,7 +199,7 @@ class IVTPipeline:
                         exclude_calibration=evaluate_exclude_calibration,
                     )
                 except Exception as e:
-                    print(f"Warning: Could not compute metrics: {e}")
+                    logger.warning("Could not compute metrics: %s", e)
             
             # Notify observers of success
             self._notify_complete(config, df, metrics)
@@ -379,10 +382,11 @@ class IVTPipeline:
         else:
             pred_sample_col = "ivt_event_type_smoothed"
         
-        print(
-            f"[Post-Processing] merged short saccade blocks: "
-            f"{merge_stats['n_blocks_merged']} / {merge_stats['n_blocks_total']} blocks, "
-            f"{merge_stats['n_samples_merged']} samples."
+        logger.info(
+            "[Post-Processing] merged short saccade blocks: %s / %s blocks, %s samples.",
+            merge_stats["n_blocks_merged"],
+            merge_stats["n_blocks_total"],
+            merge_stats["n_samples_merged"],
         )
         
         return df, pred_sample_col
@@ -414,11 +418,13 @@ class IVTPipeline:
             use_ray3d=use_ray3d,
         )
         
-        print(
-            f"[FixationPost] merged_pairs={fix_stats.get('merged_pairs', 0)}, "
-            f"gap_samples_to_fixation={fix_stats.get('gap_samples_to_fixation', 0)}, "
-            f"discarded_fixations={fix_stats.get('discarded_fixations', 0)}, "
-            f"discarded_samples={fix_stats.get('discarded_samples', 0)}"
+        logger.info(
+            "[FixationPost] merged_pairs=%s, gap_samples_to_fixation=%s, "
+            "discarded_fixations=%s, discarded_samples=%s",
+            fix_stats.get("merged_pairs", 0),
+            fix_stats.get("gap_samples_to_fixation", 0),
+            fix_stats.get("discarded_fixations", 0),
+            fix_stats.get("discarded_samples", 0),
         )
         
         return df, "ivt_event_type_post"

--- a/ivt_filter/postprocessing/merge_fixations.py
+++ b/ivt_filter/postprocessing/merge_fixations.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Tuple, Dict, Any, List
 
 import numpy as np
@@ -10,6 +11,8 @@ import pandas as pd
 
 from ..config import FixationPostConfig
 from ..strategies import Ray3DAngle, Olsen2DApproximation
+
+logger = logging.getLogger(__name__)
 
 
 def _weighted_fixation_center(
@@ -91,10 +94,10 @@ def merge_adjacent_fixations(
     # Select strategy
     if use_ray3d:
         angle_calculator = Ray3DAngle()
-        print("[MergeFixations] Using Ray3D angle calculation")
+        logger.info("[MergeFixations] Using Ray3D angle calculation")
     else:
         angle_calculator = Olsen2DApproximation()  # type: ignore[assignment]
-        print("[MergeFixations] Using Olsen 2D approximation")
+        logger.info("[MergeFixations] Using Olsen 2D approximation")
 
     # Fixations-Bloecke aus den Labels bestimmen
     events: List[Tuple[int, int]] = []

--- a/ivt_filter/processing/velocity.py
+++ b/ivt_filter/processing/velocity.py
@@ -373,12 +373,16 @@ class SamplingAnalyzer:
             else np.mean(deltas)
         )
         hz_measured = 1000.0 / dt_ms if dt_ms > 0 else float("nan")
-        print(
-            f"[Sampling] {cfg.dt_calculation_method} dt = {dt_ms:.3f} ms -> measured ~{hz_measured:.1f} Hz (using {method_desc})"
+        logger.info(
+            "[Sampling] %s dt = %.3f ms -> measured ~%.1f Hz (using %s)",
+            cfg.dt_calculation_method,
+            dt_ms,
+            hz_measured,
+            method_desc,
         )
         if math.isfinite(hz_measured):
             nearest = min(self.NOMINAL_RATES, key=lambda rate: abs(rate - hz_measured))
-            print(f"[Sampling] nearest nominal rate: {nearest:.1f} Hz")
+            logger.info("[Sampling] nearest nominal rate: %.1f Hz", nearest)
         should_convert = cfg.auto_fixed_window_from_ms or cfg.symmetric_round_window
         if should_convert and cfg.fixed_window_samples is None and dt_ms > 0:
             intervals = max(1, int(round(cfg.window_length_ms / dt_ms)))
@@ -387,8 +391,12 @@ class SamplingAnalyzer:
                 samples += 1
             effective_ms = (samples - 1) * dt_ms
             cfg = dataclasses.replace(cfg, fixed_window_samples=samples)
-            print(
-                f"[Window] auto sample window: {samples} samples total (~{(samples - 1) / 2.0:.1f} pro Seite um das Zentrum, effektive Spannweite ~{effective_ms:.2f} ms)"
+            logger.info(
+                "[Window] auto sample window: %s samples total (~%.1f pro Seite um "
+                "das Zentrum, effektive Spannweite ~%.2f ms)",
+                samples,
+                (samples - 1) / 2.0,
+                effective_ms,
             )
         return VelocityComputationResult(dt_ms, hz_measured, cfg)
 

--- a/tests/test_logging_diagnostics.py
+++ b/tests/test_logging_diagnostics.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ivt_filter.config import FixationPostConfig, IVTClassifierConfig, OlsenVelocityConfig
+from ivt_filter.io.pipeline import IVTPipeline
+from ivt_filter.postprocessing.merge_fixations import merge_adjacent_fixations
+from ivt_filter.processing.velocity import SamplingAnalyzer
+
+
+class FailingObserver:
+    def on_pipeline_start(self, config):
+        raise RuntimeError("start failure")
+
+    def on_pipeline_complete(self, config, results_df, metrics):
+        raise RuntimeError("complete failure")
+
+    def on_pipeline_error(self, config, error):
+        raise RuntimeError("error failure")
+
+
+@pytest.mark.parametrize(
+    ("notify", "args", "expected"),
+    [
+        ("_notify_start", (SimpleNamespace(),), "failed on start: start failure"),
+        (
+            "_notify_complete",
+            (SimpleNamespace(), pd.DataFrame(), None),
+            "failed on complete: complete failure",
+        ),
+        (
+            "_notify_error",
+            (SimpleNamespace(), RuntimeError("pipeline failure")),
+            "failed on error: error failure",
+        ),
+    ],
+)
+def test_pipeline_logs_observer_failures(caplog, notify, args, expected):
+    pipeline = IVTPipeline(OlsenVelocityConfig(), IVTClassifierConfig())
+    pipeline.register_observer(FailingObserver())
+
+    with caplog.at_level(logging.WARNING, logger="ivt_filter.io.pipeline"):
+        getattr(pipeline, notify)(*args)
+
+    assert expected in caplog.text
+
+
+def test_sampling_analyzer_logs_derived_window(caplog):
+    cfg = OlsenVelocityConfig(window_length_ms=20, auto_fixed_window_from_ms=True)
+
+    with caplog.at_level(logging.INFO, logger="ivt_filter.processing.velocity"):
+        result = SamplingAnalyzer().analyze(np.array([0.0, 10.0, 20.0, 30.0]), cfg)
+
+    assert result.config.fixed_window_samples == 3
+    assert "[Sampling] mean dt = 10.000 ms -> measured ~100.0 Hz" in caplog.text
+    assert "[Window] auto sample window: 3 samples total" in caplog.text
+
+
+def test_merge_fixations_logs_angle_calculation_strategy(caplog):
+    df = pd.DataFrame(
+        {
+            "ivt_sample_type": ["Fixation"],
+            "time_ms": [0.0],
+            "combined_x_mm": [0.0],
+            "combined_y_mm": [0.0],
+            "eye_z_mm": [600.0],
+        }
+    )
+
+    with caplog.at_level(logging.INFO, logger="ivt_filter.postprocessing.merge_fixations"):
+        merge_adjacent_fixations(
+            df,
+            FixationPostConfig(),
+            sample_col="ivt_sample_type",
+            time_col="time_ms",
+            x_col="combined_x_mm",
+            y_col="combined_y_mm",
+            eye_z_col="eye_z_mm",
+        )
+
+    assert "[MergeFixations] Using Olsen 2D approximation" in caplog.text
+
+
+def test_run_with_tracking_logs_metric_computation_failure(monkeypatch, caplog):
+    pipeline = IVTPipeline(OlsenVelocityConfig(), IVTClassifierConfig())
+    monkeypatch.setattr(pipeline, "run", lambda **kwargs: pd.DataFrame())
+    monkeypatch.setattr(
+        "ivt_filter.io.pipeline.compute_ivt_metrics",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("metrics failure")),
+    )
+
+    with caplog.at_level(logging.WARNING, logger="ivt_filter.io.pipeline"):
+        result = pipeline.run_with_tracking("input.tsv", SimpleNamespace(), evaluate=True)
+
+    assert result.empty
+    assert "Could not compute metrics: metrics failure" in caplog.text


### PR DESCRIPTION
### Motivation
- Reduce ad-hoc `print()` diagnostics in internal modules and surface diagnostics through the standard `logging` infrastructure. 
- Make diagnostic output testable via `caplog` while preserving intentional presentation-layer console output in reporters and CLI helpers. 
- Target modules where diagnostic `print()` calls were observed and that are internal implementation details rather than user-facing utilities.

### Description
- Added module-level `logger = logging.getLogger(__name__)` and replaced internal `print()` calls with `logger.info()` / `logger.warning()` in `ivt_filter/io/pipeline.py`. 
- Replaced sampling- and window-derivation `print()` diagnostics with `logger.info()` in `ivt_filter/processing/velocity.py` (`SamplingAnalyzer`).
- Added a module-level logger and migrated angle-strategy debug prints to `logger.info()` in `ivt_filter/postprocessing/merge_fixations.py`. 
- Left `ivt_filter/processing/velocity_parallel.py` behavior unchanged (it remains a compatibility wrapper) and added focused tests in `tests/test_logging_diagnostics.py` that use `caplog` to assert logging for observer failures, sampling diagnostics, fixation-strategy selection, and metric-computation failures.

### Testing
- Added and ran focused tests in `tests/test_logging_diagnostics.py` that assert expected messages via `caplog`, and they passed. 
- Ran targeted test subsets: `pytest -q tests/test_logging_diagnostics.py tests/test_pipeline_config.py tests/test_velocity_processing_components.py tests/test_velocity_parallel_compat.py` and observed success. 
- Ran the full test suite with `pytest -q` which completed successfully with `234 passed, 2 skipped`.