### PR TITLE
ci: enforce conservative coverage floor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pytest -q --cov=ivt_filter --cov-report=xml
+          pytest -q --cov=ivt_filter --cov-report=term-missing --cov-report=xml --cov-fail-under=55
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Motivation
- Prevent accidental decreases in tracked test coverage by enforcing a conservative CI floor while preserving the existing XML coverage artifact upload.

### Description
- Modify `.github/workflows/main.yml` to run `pytest -q --cov=ivt_filter --cov-report=term-missing --cov-report=xml --cov-fail-under=55` in the coverage step and keep the per-Python-version `coverage.xml` artifact upload.

### Testing
- Ran `pytest -q` which reported `228 passed, 2 skipped`, and measured a stable local statement-coverage baseline of `58.21%` (`2818 / 4841`) using a stdlib tracing fallback via `python /tmp/measure_ivt_trace_fast2.py` (reproduced twice); the plugin-backed `pytest-cov` coverage command could not run locally because `pytest-cov`/`coverage.py` installation was blocked by the environment proxy.