### PR TITLE
Build und Smoke-Test des Docker-Images lokal vor GHCR-Push

### DIFF
--- a/.github/workflows/ContainerRegestry.yml
+++ b/.github/workflows/ContainerRegestry.yml
@@ -18,8 +18,52 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Set image name
+        run: echo "IMAGE_NAME=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/tobii-i-vt-filter-reconstruction" >> "${GITHUB_ENV}"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image locally
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+
+      - name: Run CLI smoke test
+        run: docker run --rm "${IMAGE_NAME}:${GITHUB_REF_NAME}" --help
+
+      - name: Verify package import
+        run: docker run --rm --entrypoint python "${IMAGE_NAME}:${GITHUB_REF_NAME}" -c "import ivt_filter"
+
+      # Accepted findings:
+      # - LOW and MEDIUM vulnerabilities are reported but do not block publishing.
+      # - Unfixed vulnerabilities are temporarily accepted because no patched dependency
+      #   or base-image version is available yet. Fixable HIGH and CRITICAL findings fail the job.
+      - name: Report accepted vulnerability findings
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          format: table
+          vuln-type: os,library
+          severity: LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: false
+          exit-code: '0'
+
+      - name: Reject fixable high-severity vulnerabilities
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:${{ github.ref_name }}
+          format: table
+          vuln-type: os,library
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          exit-code: '1'
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -28,13 +72,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/tobii-i-vt-filter-reconstruction:latest
-            ghcr.io/${{ github.repository_owner }}/tobii-i-vt-filter-reconstruction:${{ github.ref_name }}
+      - name: Push Docker image
+        run: |
+          docker push "${IMAGE_NAME}:latest"
+          docker push "${IMAGE_NAME}:${GITHUB_REF_NAME}"


### PR DESCRIPTION
### Motivation
- Sicherstellen, dass nur geprüfte Images in GHCR veröffentlicht werden, indem Build, Smoke-Tests und Security-Gate vor dem Push ausgeführt werden. 
- Einfache CLI- und Import-Checks (`--help`, `import ivt_filter`) gewährleisten, dass das Paket im Image lauffähig und importierbar ist. 
- Sicherheitsbefunde sollen sichtbar dokumentiert werden und nur behebbare `HIGH`/`CRITICAL`-Vulnerabilities die Veröffentlichung blockieren.

### Description
- Normalisiert den GHCR-Repository-Owner auf Kleinschreibung und setzt `IMAGE_NAME` via `GITHUB_ENV` im Workflow. 
- Baut das Image lokal auf dem Runner mit `docker/build-push-action@v6` und `load: true`, wobei Tags `:latest` und `:${{ github.ref_name }}` gesetzt werden. 
- Führt zwei Smoke-Tests gegen das geladene Image aus: `docker run --rm "${IMAGE_NAME}:${GITHUB_REF_NAME}" --help` und `docker run --rm --entrypoint python "${IMAGE_NAME}:${GITHUB_REF_NAME}" -c "import ivt_filter"`. 
- Ergänzt einen zweistufigen Trivy-Scan: einen nicht-blockierenden Bericht aller Findings und einen blockierenden Lauf, der behebbare `HIGH`/`CRITICAL`-Funde verhindert; GHCR-Login und `docker push` erfolgen erst nach erfolgreichem Gate. 

### Testing
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ContainerRegestry.yml')"` zeigte `YAML parsed successfully` (erfolgreich). 
- `python -m ivt_filter.cli --help` lief erfolgreich und gab die CLI-Hilfe aus (erfolgreich). 
- `python -c "import ivt_filter; print('ivt_filter import successful')"` lief erfolgreich und bestätigte den Import (erfolgreich). 
- `git diff --check` und eine Normalisierungsprüfung mit `GITHUB_REPOSITORY_OWNER=cemGr` wurden ausgeführt und ergaben die erwartete kleingeschriebene `IMAGE_NAME`; der lokale `docker`-Befehl war in dieser Umgebung nicht verfügbar, daher wird der eigentliche Build/Run auf dem `ubuntu-latest` GitHub-Runner ausgeführt (Docker nicht verfügbar hier).