### PR TITLE
Remove tracked temporary lock artifacts and strengthen .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,12 +25,17 @@ venv.bak/
 .cem/
 
 # Thesis/analysis artifacts
+# The three root-level PDF files are intentionally versioned domain reference documents.
+# Keep them available for the algorithm reconstruction despite the general PDF rule.
 ACTIONABLE_ROADMAP.md
 CRITICAL_THESIS_ANALYSIS.md
 REQUIREMENTS_ANALYSIS.md
 THESIS_STATUS_SUMMARY.md
 REQ.md
 *.pdf
+!ExposeIVT.pdf
+!Eye_IVT_Filter.pdf
+!TOBII_ivt_filter.pdf
 
 # Installer logs
 pip-log.txt
@@ -68,6 +73,7 @@ test_simple_output.tsv
 
 # Lock files
 .~lock.*
+*~lock*#
 *.tsv
 *.csv
 data/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "python.testing.pytestArgs": [
-        "tests"
-    ],
-    "python.testing.unittestEnabled": false,
-    "python.testing.pytestEnabled": true
-}

--- a/data/processed/.~lock.ivt_with_classes3.tsv#
+++ b/data/processed/.~lock.ivt_with_classes3.tsv#
@@ -1,1 +1,0 @@
-,cem,cem-Laptop,26.11.2025 12:34,file:///home/cem/.config/libreoffice/4;

--- a/data/raw/.~lock.ivt_frequency120_fixation_export.tsv#
+++ b/data/raw/.~lock.ivt_frequency120_fixation_export.tsv#
@@ -1,1 +1,0 @@
-,cem,cem-Laptop,25.11.2025 08:36,file:///home/cem/.config/libreoffice/4;

--- a/data/raw/.~lock.ivt_strict_average_frequency120_moving_average_short.tsv#
+++ b/data/raw/.~lock.ivt_strict_average_frequency120_moving_average_short.tsv#
@@ -1,1 +1,0 @@
-,cem,cem-Laptop,25.11.2025 09:13,file:///home/cem/.config/libreoffice/4;


### PR DESCRIPTION
### Motivation
- Entfernen versehentlich versionierter temporärer Office-/Editor-Lock-Dateien aus den Datenverzeichnissen, um unnötige Artefakte aus dem Repository zu entfernen. 
- Verhindern der Wiederaufnahme ähnlicher Lock-Dateien durch ein robusteres Ignore-Muster für abschließende `#`-Suffixe. 
- Dokumentieren und explizit beibehalten der drei fachlich notwendigen PDF-Referenzdateien im Repo als bewusste Ausnahme von der generellen `*.pdf`-Regel. 

### Description
- Entfernt die verfolgten Lock-Dateien `data/raw/.~lock.*#` und `data/processed/.~lock.*#` sowie die workspace-spezifische Editor-Datei ` .vscode/settings.json` aus der Versionskontrolle. 
- Ergänzt `.gitignore` mit einer erklärenden Notiz zu den drei root-level PDF-Referenzen und hebt `ExposeIVT.pdf`, `Eye_IVT_Filter.pdf` und `TOBII_ivt_filter.pdf` mit Negationsmustern (`!...`) hervor. 
- Fügt das robustere Lock-Pattern `*~lock*#` hinzu, um Varianten mit abschließendem `#` zuverlässig zu ignorieren. 

### Testing
- `git ls-files data/raw data/processed` wurde ausgeführt und bestätigt, dass keine Lock-Dateien mehr in den Datenverzeichnissen verfolgt werden (erfolgreich). 
- `git ls-files -ci --exclude-standard` wurde ausgeführt und liefert keine Einträge mehr für Dateien, die durch die Standard-Ignore-Regeln ausgeschlossen sein sollten (erfolgreich). 
- `git check-ignore -v --no-index '.~lock.sample.tsv#' 'prefix~lock.document.csv#'` wurde ausgeführt und bestätigt, dass beide Testmuster vom neuen `*~lock*#`-Muster erfasst werden (erfolgreich). 
- Repository-Integritätsprüfungen wie `git diff --cached --check` / `git show --check --stat` wurden ausgeführt und zeigten keine verbleibenden Probleme (erfolgreich).
