### PR TITLE
tests: ensure legacy postprocess facade delegates and block internal legacy imports

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 import subprocess
 import sys
@@ -215,3 +216,39 @@ def test_legacy_core_imports_delegate_to_canonical_implementations() -> None:
 
 def test_obsolete_velocity_computer_module_is_removed() -> None:
     assert importlib.util.find_spec("ivt_filter.processing.velocity_computer") is None
+
+
+def test_legacy_postprocess_imports_delegate_to_canonical_implementations() -> None:
+    from ivt_filter.postprocess import (
+        apply_fixation_postprocessing as legacy_apply_fixation_postprocessing,
+    )
+    from ivt_filter.postprocess import (
+        merge_short_saccade_blocks as legacy_merge_short_saccade_blocks,
+    )
+    from ivt_filter.postprocessing import (
+        apply_fixation_postprocessing,
+        merge_short_saccade_blocks,
+    )
+
+    assert legacy_apply_fixation_postprocessing is apply_fixation_postprocessing
+    assert legacy_merge_short_saccade_blocks is merge_short_saccade_blocks
+
+
+def test_internal_modules_do_not_import_legacy_postprocess_facade() -> None:
+    package_root = REPOSITORY_ROOT / "ivt_filter"
+    legacy_facade = package_root / "postprocess.py"
+    forbidden_imports = [
+        r"^\s*from\s+ivt_filter\.postprocess\s+import\b",
+        r"^\s*import\s+ivt_filter\.postprocess(?:\s|,|$)",
+        r"^\s*from\s+\.+postprocess\s+import\b",
+    ]
+
+    for module_path in package_root.rglob("*.py"):
+        if module_path == legacy_facade:
+            continue
+        module_source = module_path.read_text(encoding="utf-8")
+        for forbidden_import in forbidden_imports:
+            assert not re.search(forbidden_import, module_source, flags=re.MULTILINE), (
+                f"{module_path.relative_to(REPOSITORY_ROOT)} must import from "
+                "ivt_filter.postprocessing instead of the legacy ivt_filter.postprocess facade"
+            )


### PR DESCRIPTION
### Motivation

- Ensure the deprecated `ivt_filter.postprocess` facade continues to delegate to the canonical `ivt_filter.postprocessing` implementations and prevent new internal modules from depending on the legacy facade.
- Keep internal modules (notably `ivt_filter/io/pipeline.py` and `ivt_filter/__init__.py`) using the canonical `ivt_filter.postprocessing` API after refactoring.

### Description

- Add `test_legacy_postprocess_imports_delegate_to_canonical_implementations()` to `tests/test_public_api.py` that imports `apply_fixation_postprocessing` and `merge_short_saccade_blocks` from both `ivt_filter.postprocess` and `ivt_filter.postprocessing` and asserts identity with `is`.
- Add `test_internal_modules_do_not_import_legacy_postprocess_facade()` to `tests/test_public_api.py` that statically scans all `*.py` files under `ivt_filter/`, skips `ivt_filter/postprocess.py`, and rejects absolute or relative imports from the legacy `ivt_filter.postprocess` facade using simple regex patterns.
- Only `tests/test_public_api.py` was modified; the check intentionally keeps the test lightweight (no AST parsing) while covering absolute and relative import cases.

### Testing

- Ran `pytest tests/test_public_api.py`, which passed with `18` tests succeeded and `1` optional Matplotlib test skipped.
- Ran the full test suite with `pytest`, which passed with `244` tests succeeded and `2` optional tests skipped.
