### PR TITLE
docs: clarify canonical postprocessing API

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -425,6 +425,10 @@ graph TB
     Strategy Layer --> Constants
 ```
 
+## Postprocessing API
+
+`ivt_filter.postprocessing` is the canonical postprocessing API. The module `ivt_filter.postprocess` is deprecated and remains temporarily available solely as a compatibility facade. New internal and external callers should use `ivt_filter.postprocessing`.
+
 ## Testing Benefits
 
 The refactored architecture provides excellent testability:


### PR DESCRIPTION
### Motivation
- Klarstellung der erwarteten Postprocessing-API: interne und externe Aufrufer sollen das neue, kanonische Modul `ivt_filter.postprocessing` verwenden und nicht das alte Kompatibilitätsmodul.

### Description
- Ein kurzer Abschnitt wurde in `docs/architecture.md` ergänzt, der `ivt_filter.postprocessing` als kanonische Postprocessing-API definiert und `ivt_filter.postprocess` als veraltete Kompatibilitätsfassade kennzeichnet.

### Testing
- Automatischer Check `git diff --check` wurde ausgeführt und meldete keine Probleme.
