### PR TITLE
docs: document canonical import paths

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -429,6 +429,18 @@ graph TB
 
 `ivt_filter.postprocessing` is the canonical postprocessing API. The module `ivt_filter.postprocess` is deprecated and remains temporarily available solely as a compatibility facade. New internal and external callers should use `ivt_filter.postprocessing`.
 
+| Alter Importpfad | Kanonischer Importpfad |
+| --- | --- |
+| `ivt_filter.postprocess` | `ivt_filter.postprocessing` |
+| `ivt_filter.core.velocity` | `ivt_filter.processing.velocity` |
+| `ivt_filter.core.classification` | `ivt_filter.processing.classification` |
+| `ivt_filter.core.gaze` | `ivt_filter.preprocessing` |
+
+Die Legacy-Pfade bleiben vorerst kompatibel.
+Neue interne und externe Aufrufer dürfen sie nicht mehr verwenden.
+Eine spätere Major-Version darf die Legacy-Pfade entfernen.
+Diese Entfernung ist eine bewusst getrennte Breaking Change und nicht Bestandteil der aktuellen Migration.
+
 ## Testing Benefits
 
 The refactored architecture provides excellent testability:


### PR DESCRIPTION
### Motivation
- Informieren über die Migration zu neuen kanonischen Importpfaden und Entwickler:innen davor warnen, die legacy-Pfade künftig zu verwenden, um die Migration vorzubereiten und eine getrennte Breaking Change in einer späteren Major-Version zu ermöglichen.

### Description
- In `docs/architecture.md` unter `## Postprocessing API` wurde eine Tabelle hinzugefügt, die die alten (Legacy) Importpfade den kanonischen Importpfaden zuordnet, sowie ein kurzer Hinweis, dass die Legacy-Pfade vorerst kompatibel bleiben, aber von neuen internen und externen Aufrufern nicht mehr verwendet werden dürfen und eine spätere Major-Version deren Entfernung als separate Breaking Change vornehmen kann.

### Testing
- Automatische Prüfung `git diff --check` ausgeführt und ergab keine Probleme.
