### PR TITLE
docs: update Python imports to canonical APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,8 +604,7 @@ ivt_filter/
 Most users just need the CLI (`python -m ivt_filter.cli`). Developers can import modules directly:
 
 ```python
-from ivt_filter.processing.velocity import compute_ray3d_velocity
-from ivt_filter.processing.classification import classify_ivt
+from ivt_filter import compute_olsen_velocity, apply_ivt_classifier
 from ivt_filter.postprocessing.merge_fixations import merge_adjacent_fixations
 from ivt_filter.evaluation.event_iou import compute_event_iou_metrics
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -52,20 +52,20 @@ Start here if you're new to the project:
 
 **Core Modules:**
 
-- **`ivt_filter.velocity_calculation`**
+- **`ivt_filter.strategies.velocity_calculation`**
   - `VelocityCalculationStrategy` (abstract base)
   - `Olsen2DApproximation` (2D method)
   - `Ray3DAngle` (3D method)
   
-- **`ivt_filter.coordinate_rounding`**
+- **`ivt_filter.strategies.coordinate_rounding`**
   - `CoordinateRoundingStrategy` (abstract base)
   - `NoRounding`, `RoundToNearest`, `RoundHalfUp`, `FloorRounding`, `CeilRounding`
   
-- **`ivt_filter.smoothing_strategy`**
+- **`ivt_filter.strategies.smoothing_strategy`**
   - `SmoothingStrategy` (abstract base)
   - `NoSmoothing`, `MedianSmoothing`, `MovingAverageSmoothing`
   
-- **`ivt_filter.window_rounding`**
+- **`ivt_filter.strategies.window_rounding`**
   - `WindowRoundingStrategy` (abstract base)
   - `StandardWindowRounding`, `SymmetricRoundWindowStrategy`
   
@@ -106,7 +106,7 @@ python -m ivt_filter.cli \
 ### Example 4: Compare Methods Programmatically
 ```python
 from ivt_filter.config import OlsenVelocityConfig
-from ivt_filter.velocity import compute_olsen_velocity
+from ivt_filter import compute_olsen_velocity
 from ivt_filter.io import read_tsv
 
 # Load data

--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -160,7 +160,7 @@ python -c "import pandas as pd; \
 
 ```python
 from ivt_filter.config import OlsenVelocityConfig
-from ivt_filter.velocity import compute_olsen_velocity
+from ivt_filter import compute_olsen_velocity
 from ivt_filter.io import read_tsv
 
 df = read_tsv("data.tsv")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -427,7 +427,7 @@ graph TB
 
 ## Postprocessing API
 
-`ivt_filter.postprocessing` is the canonical postprocessing API. The module `ivt_filter.postprocess` is deprecated and remains temporarily available solely as a compatibility facade. New internal and external callers should use `ivt_filter.postprocessing`.
+`ivt_filter.postprocessing` is the canonical postprocessing API for new internal and external callers.
 
 ## Testing Benefits
 

--- a/docs/complete_architecture.md
+++ b/docs/complete_architecture.md
@@ -414,7 +414,7 @@ classDiagram
 - **SampleValidator**: Validates eye tracking sample quality
 - **VelocityValidator**: Validates and parses velocity values
 
-### 7. Post-Processing (postprocess.py)
+### 7. Post-Processing (`ivt_filter/postprocessing/`)
 - **PostProcessor**: Saccade merging and fixation filtering
   - `merge_short_saccade_blocks()`: Merges short saccades into fixations
   - `apply_fixation_postprocessing()`: Filters fixations by duration/dispersion
@@ -457,7 +457,7 @@ Four configuration dataclasses control pipeline behavior:
 | Component | Module | Purpose |
 |-----------|--------|---------|
 | Eye data structures | `preprocessing/` | Gap filling, combined columns, smoothing |
-| Ground truth handling | `evaluation.py`, `postprocess.py` | GT column detection, event expansion |
+| Ground truth handling | `ivt_filter/evaluation/`, `ivt_filter/postprocessing/` | GT column detection, event expansion |
 | Sample data | All DataFrames | Row-based representation (time_ms + features) |
 | Evaluation | `evaluation.py` | Statistical comparison, confusion matrix |
 | Constants | `constants.py` | Physical/computational constants |
@@ -501,9 +501,9 @@ Four configuration dataclasses control pipeline behavior:
 For systematic reverse engineering, the system now includes:
 
 ```python
-from ivt_filter.experiment import ExperimentConfig, ExperimentManager
-from ivt_filter.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
-from ivt_filter.pipeline import IVTPipeline
+from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+from ivt_filter.io.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
+from ivt_filter.io.pipeline import IVTPipeline
 
 # Create experiment configuration
 exp_config = ExperimentConfig(

--- a/docs/experiment_tracking.md
+++ b/docs/experiment_tracking.md
@@ -13,7 +13,7 @@ Dieses System implementiert **automatisches Experiment-Tracking** für systemati
 Definiert eine komplette Experiment-Konfiguration:
 
 ```python
-from ivt_filter.experiment import ExperimentConfig
+from ivt_filter.evaluation.experiment import ExperimentConfig
 from ivt_filter.config import OlsenVelocityConfig, IVTClassifierConfig
 
 config = ExperimentConfig(
@@ -36,7 +36,7 @@ config = ExperimentConfig(
 Verwaltet gespeicherte Experimente (Information Expert Pattern):
 
 ```python
-from ivt_filter.experiment import ExperimentManager
+from ivt_filter.evaluation.experiment import ExperimentManager
 
 manager = ExperimentManager("experiments/")
 
@@ -66,7 +66,7 @@ Automatische Benachrichtigungen bei Pipeline-Events:
 
 **ConsoleReporter** - Konsolen-Ausgabe:
 ```python
-from ivt_filter.observers import ConsoleReporter
+from ivt_filter.io.observers import ConsoleReporter
 
 reporter = ConsoleReporter(verbose=True)
 pipeline.register_observer(reporter)
@@ -74,7 +74,7 @@ pipeline.register_observer(reporter)
 
 **MetricsLogger** - CSV-Logging:
 ```python
-from ivt_filter.observers import MetricsLogger
+from ivt_filter.io.observers import MetricsLogger
 
 logger = MetricsLogger("experiments/metrics_log.csv")
 pipeline.register_observer(logger)
@@ -82,7 +82,7 @@ pipeline.register_observer(logger)
 
 **ExperimentTracker** - Vollständiges Tracking:
 ```python
-from ivt_filter.observers import ExperimentTracker
+from ivt_filter.io.observers import ExperimentTracker
 
 tracker = ExperimentTracker("experiments/")
 pipeline.register_observer(tracker)
@@ -90,7 +90,7 @@ pipeline.register_observer(tracker)
 
 **ResultsPlotter** - Automatische Plots:
 ```python
-from ivt_filter.observers import ResultsPlotter
+from ivt_filter.io.observers import ResultsPlotter
 
 plotter = ResultsPlotter(
     output_dir="plots/",
@@ -105,9 +105,9 @@ pipeline.register_observer(plotter)
 ### Einfaches Experiment
 
 ```python
-from ivt_filter.pipeline import IVTPipeline
-from ivt_filter.experiment import ExperimentConfig
-from ivt_filter.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
+from ivt_filter.io.pipeline import IVTPipeline
+from ivt_filter.evaluation.experiment import ExperimentConfig
+from ivt_filter.io.observers import ConsoleReporter, MetricsLogger, ExperimentTracker
 
 # Pipeline mit Observers erstellen
 pipeline = IVTPipeline(velocity_config, classifier_config)
@@ -168,7 +168,7 @@ for threshold in thresholds:
 ### Experimente vergleichen
 
 ```python
-from ivt_filter.experiment import ExperimentManager
+from ivt_filter.evaluation.experiment import ExperimentManager
 
 manager = ExperimentManager("experiments/")
 
@@ -274,7 +274,7 @@ class PipelineObserver(ABC):
 ### Eigene Observer erstellen
 
 ```python
-from ivt_filter.observers import PipelineObserver
+from ivt_filter.io.observers import PipelineObserver
 
 class SlackNotifier(PipelineObserver):
     """Sendet Benachrichtigungen an Slack."""

--- a/docs/parallelization_guide.md
+++ b/docs/parallelization_guide.md
@@ -48,7 +48,7 @@ for i in range(n):
 #### 1.1 Olsen2D Vektorisiert
 
 ```python
-# ivt_filter/velocity_calculation.py
+# ivt_filter/strategies/velocity_calculation.py
 import numpy as np
 
 class Olsen2DVectorized(VelocityCalculationStrategy):
@@ -287,7 +287,9 @@ def compute_olsen_velocity(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.Dat
 import time
 import numpy as np
 import pandas as pd
-from ivt_filter.velocity_calculation import Olsen2DApproximation, Olsen2DVectorized
+from ivt_filter.strategies.velocity_calculation import Olsen2DApproximation
+
+# Olsen2DVectorized is the proposed class from section 1.1 above.
 
 def benchmark_velocity_calculation():
     # Test-Daten generieren

--- a/docs/refactoring_summary.md
+++ b/docs/refactoring_summary.md
@@ -264,7 +264,7 @@ All changes maintain backward compatibility:
 from extractor import convert_tobii_tsv_to_ivt_tsv
 convert_tobii_tsv_to_ivt_tsv("input.tsv", "output.tsv")
 
-from ivt_filter.classification import apply_ivt_classifier
+from ivt_filter.processing.classification import apply_ivt_classifier
 df = apply_ivt_classifier(df, cfg)
 
 # New code provides better structure
@@ -272,7 +272,7 @@ from extractor import TobiiDataExtractor
 extractor = TobiiDataExtractor()
 extractor.extract("input.tsv", "output.tsv")
 
-from ivt_filter.classification import IVTClassifier
+from ivt_filter.processing.classification import IVTClassifier
 classifier = IVTClassifier(cfg)
 df = classifier.classify(df)
 ```

--- a/docs/window_sizing_guide.md
+++ b/docs/window_sizing_guide.md
@@ -32,8 +32,8 @@ n_samples = 3  # Immer 3 Samples
 
 ### 1. Time-Based (einfachste Methode)
 ```python
-from ivt_filter.window_utils import create_time_based_config
-from ivt_filter.pipeline import IVTPipeline
+from ivt_filter.utils.window_utils import create_time_based_config
+from ivt_filter.io.pipeline import IVTPipeline
 
 # Immer 20 ms verwenden
 vel_cfg, clf_cfg = create_time_based_config(window_ms=20.0)
@@ -44,7 +44,7 @@ df = pipeline.run("data.tsv")
 
 ### 2. Sample-Based (empfohlen für Multi-Rate)
 ```python
-from ivt_filter.window_utils import create_sample_based_config
+from ivt_filter.utils.window_utils import create_sample_based_config
 
 # Immer 3 Samples verwenden
 vel_cfg, clf_cfg = create_sample_based_config(
@@ -58,7 +58,7 @@ df = pipeline.run("data.tsv")
 
 ### 3. Adaptive (automatisch)
 ```python
-from ivt_filter.window_utils import create_adaptive_config
+from ivt_filter.utils.window_utils import create_adaptive_config
 from ivt_filter.io import read_tsv
 
 # Automatisch Rate erkennen und anpassen
@@ -73,8 +73,8 @@ df = pipeline.run("data.tsv")
 
 ### Time-Based Window Sweep
 ```python
-from ivt_filter.experiment import ExperimentConfig
-from ivt_filter.observers import ConsoleReporter, ExperimentTracker
+from ivt_filter.evaluation.experiment import ExperimentConfig
+from ivt_filter.io.observers import ConsoleReporter, ExperimentTracker
 
 # Verschiedene Zeit-Fenster testen
 for window_ms in [10.0, 20.0, 40.0, 60.0]:
@@ -120,7 +120,7 @@ for n_samples in [2, 3, 4, 5, 7]:
 
 ### Umrechnung
 ```python
-from ivt_filter.window_utils import samples_to_milliseconds, milliseconds_to_samples
+from ivt_filter.utils.window_utils import samples_to_milliseconds, milliseconds_to_samples
 
 # Samples → Millisekunden
 ms = samples_to_milliseconds(3, 120.0)
@@ -133,7 +133,7 @@ print(n)  # 2 samples
 
 ### Sampling-Rate erkennen
 ```python
-from ivt_filter.window_utils import detect_sampling_rate
+from ivt_filter.utils.window_utils import detect_sampling_rate
 from ivt_filter.io import read_tsv
 
 df = read_tsv("data.tsv")
@@ -143,7 +143,7 @@ print(f"Detected: {rate} Hz")  # z.B. 120.0 Hz
 
 ### Window-Info anzeigen
 ```python
-from ivt_filter.window_utils import print_window_info
+from ivt_filter.utils.window_utils import print_window_info
 
 print_window_info(20.0, 120.0)
 # Output:
@@ -156,7 +156,7 @@ print_window_info(20.0, 120.0)
 
 ### Empfehlungen erhalten
 ```python
-from ivt_filter.window_utils import recommend_window_size
+from ivt_filter.utils.window_utils import recommend_window_size
 
 recommendations = recommend_window_size(120.0)
 for n_samples, window_ms in recommendations:
@@ -201,14 +201,14 @@ vel_cfg, clf_cfg = create_sample_based_config(n_samples=3, sampling_rate_hz=rate
 
 ```python
 from ivt_filter.io import read_tsv
-from ivt_filter.window_utils import (
+from ivt_filter.utils.window_utils import (
     detect_sampling_rate,
     create_sample_based_config,
     recommend_window_size
 )
-from ivt_filter.experiment import ExperimentConfig, ExperimentManager
-from ivt_filter.observers import ConsoleReporter, ExperimentTracker
-from ivt_filter.pipeline import IVTPipeline
+from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+from ivt_filter.io.observers import ConsoleReporter, ExperimentTracker
+from ivt_filter.io.pipeline import IVTPipeline
 
 # 1. Daten laden und Rate erkennen
 df = read_tsv("data.tsv")

--- a/examples/velocity_comparison.py
+++ b/examples/velocity_comparison.py
@@ -13,7 +13,7 @@ import sys
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from ivt_filter.config import OlsenVelocityConfig
-from ivt_filter.velocity import compute_olsen_velocity
+from ivt_filter import compute_olsen_velocity
 from ivt_filter.io import read_tsv
 
 


### PR DESCRIPTION
### Motivation
- Remove fragile/removed module paths in documentation and examples and point readers to the repository's canonical, exported APIs. 
- Ensure runnable examples use only exported symbols (e.g. `compute_olsen_velocity`, `apply_ivt_classifier`) so pasted snippets import successfully. 
- Replace descriptive references to the deprecated `postprocess.py` facade with the canonical `ivt_filter/postprocessing/` package to reduce confusion. 

### Description
- Updated import examples across docs and examples to use package-root exports and canonical subpackages (notable replacements include `from ivt_filter import compute_olsen_velocity, apply_ivt_classifier`, `ivt_filter.processing.classification`, `ivt_filter.strategies.velocity_calculation`, `ivt_filter.io.observers`, `ivt_filter.io.pipeline`, and `ivt_filter.utils.window_utils`). 
- Rewrote prose references to post-processing to point to `ivt_filter/postprocessing/` instead of `postprocess.py` and simplified the architecture note to avoid promoting the legacy facade. 
- Adjusted the parallelization guide so the benchmark imports the existing `Olsen2DApproximation` and documents that `Olsen2DVectorized` is a proposed example class in the guide rather than an exported symbol. 
- Files changed include `README.md`, `docs/INDEX.md`, `docs/QUICK_REFERENCE.md`, `docs/architecture.md`, `docs/complete_architecture.md`, `docs/experiment_tracking.md`, `docs/parallelization_guide.md`, `docs/refactoring_summary.md`, `docs/window_sizing_guide.md`, and `examples/velocity_comparison.py`. 

### Testing
- Ran `git diff --check` and a repository-wide `rg` scan for deprecated paths in the targeted areas and found no remaining deprecated references. 
- Performed an AST-based import validation over `README.md`, `docs/*.md`, `examples/`, root example scripts and `notebooks/*.ipynb`, which validated `30` unique `ivt_filter` imports. 
- Compiled code with `python -m compileall` for `ivt_filter` and the example scripts without errors. 
- Ran the full test suite with `pytest`, resulting in `244` passed and `2` skipped.

