### PR TITLE
Test: forbid legacy facade references outside compatibility boundaries

### DIFF
--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,4 +1,5 @@
 """Smoke tests for supported public imports and optional plotting behavior."""
+
 from __future__ import annotations
 
 import ast
@@ -13,7 +14,6 @@ import pandas as pd
 import pytest
 
 from ivt_filter.config import OlsenVelocityConfig
-
 
 REPOSITORY_ROOT = Path(__file__).parent.parent
 COMPATIBILITY_FACADES = {
@@ -40,9 +40,9 @@ def _compatibility_symbol_cases() -> list[object]:
                 for canonical_module_name in canonical_module_names
                 if hasattr(importlib.import_module(canonical_module_name), symbol_name)
             ]
-            assert len(matching_canonical_modules) == 1, (
-                f"{facade_name}.{symbol_name} must have exactly one canonical public source"
-            )
+            assert (
+                len(matching_canonical_modules) == 1
+            ), f"{facade_name}.{symbol_name} must have exactly one canonical public source"
             cases.append(
                 pytest.param(
                     facade_name,
@@ -59,6 +59,7 @@ EXAMPLE_MODULES = [
     "example_sample_based_window.py",
     "example_window_sweep.py",
     "quick_window_test.py",
+    "examples/velocity_comparison.py",
 ]
 
 
@@ -115,7 +116,12 @@ def test_import_canonical_public_api() -> None:
 
 
 def test_import_convenience_subpackages() -> None:
-    from ivt_filter.io import ExperimentTracker, IVTPipeline, PipelineObserver, ResultsPlotter
+    from ivt_filter.io import (
+        ExperimentTracker,
+        IVTPipeline,
+        PipelineObserver,
+        ResultsPlotter,
+    )
     from ivt_filter.utils import estimate_sampling_rate, samples_to_milliseconds
 
     assert all(
@@ -176,7 +182,9 @@ print("optional plotting dependency was not imported")
     assert "optional plotting dependency was not imported" in completed.stdout
 
 
-def test_plotting_error_explains_optional_extra_when_matplotlib_is_unavailable() -> None:
+def test_plotting_error_explains_optional_extra_when_matplotlib_is_unavailable() -> (
+    None
+):
     script = """
 import importlib.util
 original_find_spec = importlib.util.find_spec
@@ -195,7 +203,9 @@ from ivt_filter.evaluation.plotting import plot_velocity_only
     assert "pip install tobii-ivt-filter[plot]" in completed.stderr
 
 
-def test_plotting_works_when_matplotlib_is_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_plotting_works_when_matplotlib_is_installed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     pytest.importorskip("matplotlib")
     from matplotlib import pyplot as plt
     from ivt_filter.evaluation.plotting import plot_velocity_only
@@ -255,10 +265,14 @@ def test_compatibility_facade_symbols_delegate_to_canonical_implementations(
 
 
 @pytest.mark.parametrize("facade_name", COMPATIBILITY_FACADES)
-def test_compatibility_facades_contain_no_implementation_logic(facade_name: str) -> None:
+def test_compatibility_facades_contain_no_implementation_logic(
+    facade_name: str,
+) -> None:
     facade = importlib.import_module(facade_name)
     facade_path = Path(facade.__file__)
-    module = ast.parse(facade_path.read_text(encoding="utf-8"), filename=str(facade_path))
+    module = ast.parse(
+        facade_path.read_text(encoding="utf-8"), filename=str(facade_path)
+    )
 
     for statement in module.body:
         if isinstance(statement, ast.Expr):
@@ -282,21 +296,109 @@ def test_obsolete_velocity_computer_module_is_removed() -> None:
     assert importlib.util.find_spec("ivt_filter.processing.velocity_computer") is None
 
 
-def test_internal_modules_do_not_import_legacy_postprocess_facade() -> None:
+LEGACY_MODULE_PREFIXES = ("ivt_filter.postprocess", "ivt_filter.core")
+LEGACY_TEXT_PATTERN = re.compile(
+    r"(?:\bivt_filter\.(?:postprocess|core)\b|"
+    r"\bfrom\s+ivt_filter\s+import\s+(?:[^#\n]*,\s*)?(?:postprocess|core)\b|"
+    r"\bfrom\s+\.+(?:postprocess|core)\b|"
+    r"\bfrom\s+\.+\s+import\s+(?:[^#\n]*,\s*)?(?:postprocess|core)\b)"
+)
+MIGRATION_TABLE_LEGACY_REFERENCES = {
+    "docs/architecture.md": {
+        "| `ivt_filter.postprocess` | `ivt_filter.postprocessing` |",
+        "| `ivt_filter.core.velocity` | `ivt_filter.processing.velocity` |",
+        "| `ivt_filter.core.classification` | `ivt_filter.processing.classification` |",
+        "| `ivt_filter.core.gaze` | `ivt_filter.preprocessing` |",
+    }
+}
+
+
+def _is_legacy_module(module_name: str) -> bool:
+    return any(
+        module_name == prefix or module_name.startswith(f"{prefix}.")
+        for prefix in LEGACY_MODULE_PREFIXES
+    )
+
+
+def _module_name(module_path: Path) -> str:
+    relative_path = module_path.relative_to(REPOSITORY_ROOT).with_suffix("")
+    parts = relative_path.parts
+    if parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _imported_module_names(
+    statement: ast.Import | ast.ImportFrom, package: str
+) -> set[str]:
+    if isinstance(statement, ast.Import):
+        return {alias.name for alias in statement.names}
+
+    imported_from = statement.module or ""
+    if statement.level:
+        imported_from = importlib.util.resolve_name(
+            f"{'.' * statement.level}{imported_from}", package
+        )
+
+    imported_modules = {imported_from} if imported_from else set()
+    imported_modules.update(
+        f"{imported_from}.{alias.name}" if imported_from else alias.name
+        for alias in statement.names
+        if alias.name != "*"
+    )
+    return imported_modules
+
+
+def test_productive_modules_do_not_import_legacy_facades() -> None:
     package_root = REPOSITORY_ROOT / "ivt_filter"
     legacy_facade = package_root / "postprocess.py"
-    forbidden_imports = [
-        r"^\s*from\s+ivt_filter\.postprocess\s+import\b",
-        r"^\s*import\s+ivt_filter\.postprocess(?:\s|,|$)",
-        r"^\s*from\s+\.+postprocess\s+import\b",
-    ]
+    legacy_core = package_root / "core"
 
     for module_path in package_root.rglob("*.py"):
-        if module_path == legacy_facade:
+        if module_path == legacy_facade or legacy_core in module_path.parents:
             continue
-        module_source = module_path.read_text(encoding="utf-8")
-        for forbidden_import in forbidden_imports:
-            assert not re.search(forbidden_import, module_source, flags=re.MULTILINE), (
-                f"{module_path.relative_to(REPOSITORY_ROOT)} must import from "
-                "ivt_filter.postprocessing instead of the legacy ivt_filter.postprocess facade"
+
+        module_name = _module_name(module_path)
+        package = (
+            module_name
+            if module_path.name == "__init__.py"
+            else module_name.rpartition(".")[0]
+        )
+        module = ast.parse(
+            module_path.read_text(encoding="utf-8"), filename=str(module_path)
+        )
+        for statement in ast.walk(module):
+            if not isinstance(statement, (ast.Import, ast.ImportFrom)):
+                continue
+            legacy_imports = sorted(
+                imported_module
+                for imported_module in _imported_module_names(statement, package)
+                if _is_legacy_module(imported_module)
             )
+            assert not legacy_imports, (
+                f"{module_path.relative_to(REPOSITORY_ROOT)}:{statement.lineno} must not "
+                f"import legacy facade(s) {legacy_imports}; use canonical modules instead"
+            )
+
+
+def _documentation_and_example_files() -> set[Path]:
+    paths = {REPOSITORY_ROOT / "README.md", REPOSITORY_ROOT / "quick_window_test.py"}
+    paths.update(REPOSITORY_ROOT.glob("example_*.py"))
+    paths.update((REPOSITORY_ROOT / "docs").rglob("*.md"))
+    paths.update((REPOSITORY_ROOT / "examples").rglob("*.py"))
+    paths.update((REPOSITORY_ROOT / "notebooks").rglob("*.ipynb"))
+    return paths
+
+
+def test_documentation_and_examples_do_not_recommend_legacy_imports() -> None:
+    for file_path in sorted(_documentation_and_example_files()):
+        relative_path = file_path.relative_to(REPOSITORY_ROOT).as_posix()
+        allowed_lines = MIGRATION_TABLE_LEGACY_REFERENCES.get(relative_path, set())
+        for line_number, line in enumerate(
+            file_path.read_text(encoding="utf-8").splitlines(), 1
+        ):
+            if LEGACY_TEXT_PATTERN.search(line):
+                assert line.strip() in allowed_lines, (
+                    f"{relative_path}:{line_number} references a legacy import outside the "
+                    "documented migration table"
+                )


### PR DESCRIPTION
### Motivation
- Prevent productive modules from depending on legacy facade paths (`ivt_filter.postprocess`, `ivt_filter.core`) while keeping explicit compatibility facades allowed. 
- Ensure documentation and examples do not recommend legacy imports except in the documented migration table. 
- Extend smoke/import checks to include the `examples/velocity_comparison.py` example.

### Description
- Replace a narrow regex check with an AST-based import validator in `tests/test_public_api.py` that inspects `ast.Import` and `ast.ImportFrom`, resolves relative imports and detects alias forms using `_imported_module_names` and `_is_legacy_module` helpers. 
- Exclude the allowed legacy façades `ivt_filter/postprocess.py` and the `ivt_filter/core/` package from the productive-module check, and raise an assertion for any other productive module importing legacy prefixes. 
- Add a separate static text scanner for `README.md`, `docs/**/*.md`, `example_*.py`, `quick_window_test.py`, `examples/**/*.py`, and `notebooks/**/*.ipynb` that only permits legacy paths listed in the `MIGRATION_TABLE_LEGACY_REFERENCES`. 
- Include `examples/velocity_comparison.py` in the executable example import smoke tests by updating `EXAMPLE_MODULES`.

### Testing
- Ran `black tests/test_public_api.py` to apply formatting changes and ensure the file is well-formed. 
- Ran `pytest -q` against the repository, which passed with `284 passed, 2 skipped`. 
- Executed an inline AST helper verification script that asserted detection of 10 forbidden import variants (absolute, relative, and aliased forms) which completed successfully.