### PR TITLE
docs: clarify postprocessing API breaking change

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -436,10 +436,8 @@ graph TB
 | `ivt_filter.core.classification` | `ivt_filter.processing.classification` |
 | `ivt_filter.core.gaze` | `ivt_filter.preprocessing` |
 
-Die Legacy-Pfade bleiben vorerst kompatibel.
-Neue interne und externe Aufrufer dürfen sie nicht mehr verwenden.
-Eine spätere Major-Version darf die Legacy-Pfade entfernen.
-Diese Entfernung ist eine bewusst getrennte Breaking Change und nicht Bestandteil der aktuellen Migration.
+> **Breaking Change:** `ivt_filter.postprocess` wurde entfernt. Der neue kanonische Importpfad ist `ivt_filter.postprocessing`.
+> Die Fassaden unter `ivt_filter/core/` bleiben vorerst erhalten. Ihre spätere Entfernung ist ausdrücklich ein separater Breaking Change.
 
 ## Testing Benefits
 


### PR DESCRIPTION
### Motivation
- Die Dokumentation soll klar kommunizieren, dass der alte Importpfad `ivt_filter.postprocess` entfernt wurde und nicht mehr importierbar ist.
- Nutzer müssen den Ersatzpfad leicht erkennen können, ohne dass gleichzeitig fälschlich die Entfernung von `ivt_filter/core/` suggeriert wird.

### Description
- Aktualisiert den Abschnitt `## Postprocessing API` in `docs/architecture.md` und belässt die Migrationszeile `| `ivt_filter.postprocess` | `ivt_filter.postprocessing` |` unverändert zur direkten Auffindbarkeit des Ersatzes.
- Ersetzt die pauschale Aussage zur „vorerst kompatiblen“ Legacy-Nutzung durch eine explizite Breaking-Change-Notiz, die festhält, dass `ivt_filter.postprocess` entfernt wurde und `ivt_filter.postprocessing` der kanonische Importpfad ist.
- Fügt ausdrücklich hinzu, dass die Fassaden unter `ivt_filter/core/` vorerst erhalten bleiben und dass deren spätere Entfernung ein separater Breaking Change ist.
- Entfernt jede Formulierung, die nahelegt, dass `ivt_filter.postprocess` weiterhin importierbar ist.

### Testing
- Ausgeführt: `git diff --check` und es gab keine Fehler bei der Formatprüfung.
- Ausgeführt: `rg -n "postprocess|postprocessing|ivt_filter/core|Legacy-Pfade" docs/architecture.md` zur Verifikation der aktualisierten Referenzen.
- Ausgeführt: `git status --porcelain` zur Bestätigung eines sauberen Arbeitsverzeichnisses.
- Ausgeführt: `git show --check --stat --oneline HEAD` zur Übersicht über die Änderung und Prüfstatus.

