### PR TITLE
docs: announce removal of legacy postprocessing import path (breaking change)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -436,10 +436,8 @@ graph TB
 | `ivt_filter.core.classification` | `ivt_filter.processing.classification` |
 | `ivt_filter.core.gaze` | `ivt_filter.preprocessing` |
 
-Die Legacy-Pfade bleiben vorerst kompatibel.
-Neue interne und externe Aufrufer dürfen sie nicht mehr verwenden.
-Eine spätere Major-Version darf die Legacy-Pfade entfernen.
-Diese Entfernung ist eine bewusst getrennte Breaking Change und nicht Bestandteil der aktuellen Migration.
+> **Breaking Change:** Der in der Tabelle aufgeführte alte Postprocessing-Importpfad wurde entfernt. Der neue kanonische Importpfad ist `ivt_filter.postprocessing`.
+> Die Fassaden unter `ivt_filter/core/` bleiben vorerst erhalten. Ihre spätere Entfernung ist ausdrücklich ein separater Breaking Change.
 
 ## Testing Benefits
 


### PR DESCRIPTION
### Motivation
- Update the architecture documentation to reflect the removal of the legacy postprocessing import path and to clarify the migration and facade removal policy.

### Description
- Replace the previous German bullet list with a clear Breaking Change notice stating that the old postprocessing import path was removed and the canonical path is `ivt_filter.postprocessing`.
- Clarify that facade modules under `ivt_filter/core/` remain temporarily and that their future removal will be an explicitly separate breaking change.

### Testing
- No automated tests were run for this documentation-only change.