### PR TITLE
Validate and preserve timestamp provenance for velocity processing

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import Optional, Dict
 import pandas as pd
 
+from ivt_filter.utils.sampling import sort_by_time_with_source_row_id
+
 
 # Mapping from slim TSV column names to original Tobii TSV headers.
 RAW_COLUMNS = {
@@ -236,10 +238,8 @@ class TobiiDataExtractor:
         return target
 
     def _sort_by_time(self, df: pd.DataFrame) -> pd.DataFrame:
-        """Sort DataFrame by timestamp."""
-        if "time_ms" in df.columns:
-            return df.sort_values("time_ms").reset_index(drop=True)
-        return df
+        """Validate and stably sort timestamps while retaining source-row provenance."""
+        return sort_by_time_with_source_row_id(df)
 
     def _write_data(self, df: pd.DataFrame, path: str | Path) -> None:
         """Write DataFrame to TSV with Tobii format."""

--- a/ivt_filter/processing/velocity_input.py
+++ b/ivt_filter/processing/velocity_input.py
@@ -11,6 +11,11 @@ import pandas as pd
 
 from ..config import OlsenVelocityConfig
 from ..domain.schema import validate_preprocessed_frame, validate_raw_gaze_frame
+from ..utils.sampling import (
+    coerce_finite_timestamps,
+    positive_timestamp_deltas,
+    sort_by_time_with_source_row_id,
+)
 from ..preprocessing import (
     apply_tobii_eye_offset_interpolation,
     gap_fill_gaze,
@@ -74,18 +79,13 @@ class SamplingAnalyzer:
     def analyze(
         self, times: np.ndarray, cfg: OlsenVelocityConfig
     ) -> VelocityComputationResult:
-        if len(times) < 2:
-            return VelocityComputationResult(None, None, cfg)
         if cfg.sampling_rate_method == "first_100":
             sample_count = min(100, len(times) - 1)
-            deltas = np.diff(times[: sample_count + 1])
+            deltas = positive_timestamp_deltas(times[: sample_count + 1])
             method_desc = f"first {sample_count} samples"
         else:
-            deltas = np.diff(times)
+            deltas = positive_timestamp_deltas(times)
             method_desc = "all samples"
-        deltas = deltas[np.isfinite(deltas)]
-        if deltas.size == 0:
-            return VelocityComputationResult(None, None, cfg)
         dt_ms = float(
             np.median(deltas)
             if cfg.dt_calculation_method == "median"
@@ -128,8 +128,9 @@ def normalize_timestamps(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataF
     if time_col not in result.columns:
         raise ValueError(f"DataFrame must contain '{time_col}' column")
     divisor = {"ms": 1.0, "us": 1000.0, "ns": 1_000_000.0}.get(time_unit, 1.0)
-    result["time_ms"] = result[time_col].astype(float) / divisor
-    return result.sort_values("time_ms").reset_index(drop=True)
+    timestamps = coerce_finite_timestamps(result[time_col], time_col=time_col)
+    result["time_ms"] = timestamps / divisor
+    return sort_by_time_with_source_row_id(result)
 
 
 def prepare_velocity_input(df: pd.DataFrame, cfg: OlsenVelocityConfig) -> pd.DataFrame:

--- a/ivt_filter/processing/velocity_samples.py
+++ b/ivt_filter/processing/velocity_samples.py
@@ -421,6 +421,8 @@ def _compute_olsen_velocity_impl(
             combined_dir_z[i] = rdz[i]
 
     n = len(df)
+    if n == 0:
+        return df
 
     # Sampling analysis can adjust the effective fixed-window configuration.
     sampling = SamplingAnalyzer().analyze(times, cfg)

--- a/ivt_filter/utils/sampling.py
+++ b/ivt_filter/utils/sampling.py
@@ -6,12 +6,85 @@ import numpy as np
 import pandas as pd
 
 
+SOURCE_ROW_ID_COLUMN = "source_row_id"
+
+
 KNOWN_SAMPLING_RATES = [
     30.0, 50.0, 60.0, 90.0,
     120.0, 125.0, 150.0, 200.0,
     250.0, 300.0, 500.0, 600.0,
     1000.0, 1200.0, 2000.0,
 ]
+
+
+def _invalid_value_details(values: pd.Series, mask: np.ndarray) -> str:
+    """Return a compact source-row report for invalid timestamp values."""
+    positions = np.flatnonzero(mask)
+    details = [f"{position}: {values.iloc[position]!r}" for position in positions[:10]]
+    if len(positions) > 10:
+        details.append(f"... and {len(positions) - 10} more")
+    return ", ".join(details)
+
+
+def coerce_finite_timestamps(values: pd.Series, *, time_col: str) -> pd.Series:
+    """Convert timestamps to floats and explicitly reject unusable values."""
+    numeric = pd.to_numeric(values, errors="coerce")
+    non_numeric = numeric.isna().to_numpy()
+    numeric_values = numeric.to_numpy(dtype=float)
+    non_finite = ~non_numeric & ~np.isfinite(numeric_values)
+
+    errors = []
+    if np.any(non_numeric):
+        errors.append(
+            "non-numeric or missing values at source rows "
+            f"[{_invalid_value_details(values, non_numeric)}]"
+        )
+    if np.any(non_finite):
+        errors.append(
+            "non-finite values at source rows "
+            f"[{_invalid_value_details(values, non_finite)}]"
+        )
+    if errors:
+        raise ValueError(
+            f"Timestamp column '{time_col}' must contain only numeric, finite values: "
+            + "; ".join(errors)
+        )
+    return numeric.astype(float)
+
+
+def sort_by_time_with_source_row_id(
+    df: pd.DataFrame, *, time_col: str = "time_ms"
+) -> pd.DataFrame:
+    """Validate timestamps, reject duplicates, and stably sort with provenance."""
+    if time_col not in df.columns:
+        raise ValueError(f"DataFrame must contain '{time_col}' column.")
+
+    result = df.copy()
+    if SOURCE_ROW_ID_COLUMN not in result.columns:
+        result[SOURCE_ROW_ID_COLUMN] = np.arange(len(result))
+    result[time_col] = coerce_finite_timestamps(result[time_col], time_col=time_col)
+
+    duplicate_mask = result[time_col].duplicated(keep=False)
+    if duplicate_mask.any():
+        duplicates = result.loc[duplicate_mask, time_col].drop_duplicates().tolist()
+        raise ValueError(
+            f"Timestamp column '{time_col}' contains duplicate timestamps; "
+            f"duplicates are rejected for reproducible processing: {duplicates}"
+        )
+
+    return result.sort_values(time_col, kind="stable").reset_index(drop=True)
+
+
+def positive_timestamp_deltas(times: np.ndarray) -> np.ndarray:
+    """Return finite, strictly positive intervals or reject unusable samples."""
+    deltas = np.diff(times)
+    deltas = deltas[np.isfinite(deltas) & (deltas > 0)]
+    if deltas.size == 0:
+        raise ValueError(
+            "No finite, strictly positive timestamp intervals remain to estimate "
+            "the sampling rate."
+        )
+    return deltas
 
 
 def _nearest_nominal_rate(hz_measured: float) -> float:
@@ -52,11 +125,7 @@ def estimate_sampling_rate(
     if len(times) < 2:
         raise ValueError("Need at least two time samples to estimate sampling rate.")
 
-    diffs = np.diff(times)
-    # Only use positive differences (in case of 0 or backwards jumps)
-    diffs = diffs[diffs > 0]
-    if len(diffs) == 0:
-        raise ValueError("No positive time differences found to estimate sampling rate.")
+    diffs = positive_timestamp_deltas(times)
 
     median_dt_ms = float(np.median(diffs))
     mean_dt_ms = float(np.mean(diffs))

--- a/tests/test_velocity_processing_components.py
+++ b/tests/test_velocity_processing_components.py
@@ -2,6 +2,9 @@ import math
 
 import numpy as np
 import pandas as pd
+import pytest
+
+from extractor import TobiiDataExtractor
 
 from ivt_filter.config import OlsenVelocityConfig
 from ivt_filter.processing.velocity import (
@@ -22,6 +25,7 @@ from ivt_filter.strategies import (
     Olsen2DApproximation,
     VelocityContext,
 )
+from ivt_filter.utils.sampling import estimate_sampling_rate
 
 
 def test_normalize_timestamps_converts_microseconds_and_sorts_copy():
@@ -32,12 +36,79 @@ def test_normalize_timestamps_converts_microseconds_and_sorts_copy():
     assert "time_ms" not in original
 
 
+def test_normalize_timestamps_retains_source_row_provenance_after_sorting():
+    result = normalize_timestamps(
+        pd.DataFrame({"time_ms": [30, 10, 20], "value": ["third", "first", "second"]}),
+        OlsenVelocityConfig(),
+    )
+    assert result["time_ms"].tolist() == [10.0, 20.0, 30.0]
+    assert result["source_row_id"].tolist() == [1, 2, 0]
+    assert result["value"].tolist() == ["first", "second", "third"]
+
+
+def test_normalize_timestamps_preserves_existing_source_row_identifier():
+    result = normalize_timestamps(
+        pd.DataFrame({"time_ms": [20, 10], "source_row_id": ["b", "a"]}),
+        OlsenVelocityConfig(),
+    )
+    assert result["source_row_id"].tolist() == ["a", "b"]
+
+
+def test_normalize_timestamps_rejects_duplicate_timestamps():
+    with pytest.raises(ValueError, match="duplicate timestamps.*rejected"):
+        normalize_timestamps(pd.DataFrame({"time_ms": [10, 10]}), OlsenVelocityConfig())
+
+
+@pytest.mark.parametrize("invalid_timestamp", ["not-a-number", np.nan, np.inf, -np.inf])
+def test_normalize_timestamps_rejects_non_numeric_and_non_finite_values(
+    invalid_timestamp,
+):
+    with pytest.raises(ValueError, match="numeric, finite values"):
+        normalize_timestamps(
+            pd.DataFrame({"time_ms": [0, invalid_timestamp]}), OlsenVelocityConfig()
+        )
+
+
+def test_extractor_sort_by_time_uses_same_duplicate_rejection_policy():
+    with pytest.raises(ValueError, match="duplicate timestamps.*rejected"):
+        TobiiDataExtractor()._sort_by_time(pd.DataFrame({"time_ms": [10, 10]}))
+
+
 def test_sampling_analyzer_derives_odd_fixed_sample_window():
     cfg = OlsenVelocityConfig(window_length_ms=20, auto_fixed_window_from_ms=True)
     result = SamplingAnalyzer().analyze(np.array([0.0, 10.0, 20.0, 30.0]), cfg)
     assert result.dt_ms == 10.0
     assert result.hz_measured == 100.0
     assert result.config.fixed_window_samples == 3
+
+
+def test_sampling_analyzer_uses_only_finite_strictly_positive_intervals():
+    result = SamplingAnalyzer().analyze(
+        np.array([0.0, 10.0, 10.0, 5.0, np.inf, 25.0]), OlsenVelocityConfig()
+    )
+    assert result.dt_ms == 10.0
+    assert result.hz_measured == 100.0
+
+
+def test_sampling_analyzer_rejects_input_without_valid_interval():
+    with pytest.raises(ValueError, match="finite, strictly positive timestamp intervals"):
+        SamplingAnalyzer().analyze(np.array([10.0, 10.0, 5.0, np.inf]), OlsenVelocityConfig())
+
+
+def test_sampling_analyzer_rejects_input_without_any_interval():
+    with pytest.raises(ValueError, match="finite, strictly positive timestamp intervals"):
+        SamplingAnalyzer().analyze(np.array([10.0]), OlsenVelocityConfig())
+
+
+def test_sampling_utility_uses_only_finite_strictly_positive_intervals():
+    result = estimate_sampling_rate(pd.DataFrame({"time_ms": [0, 10, 10, 5, np.inf, 25]}))
+    assert result["median_dt_ms"] == 10.0
+    assert result["mean_dt_ms"] == 10.0
+
+
+def test_sampling_utility_rejects_input_without_valid_interval():
+    with pytest.raises(ValueError, match="finite, strictly positive timestamp intervals"):
+        estimate_sampling_rate(pd.DataFrame({"time_ms": [10, 10, 5, np.inf]}))
 
 
 def test_neighbor_imputer_uses_closest_valid_missing_eye_sample():


### PR DESCRIPTION
### Motivation
- Ensure timestamp inputs are validated early and consistently to avoid silently propagating non-numeric, non-finite or duplicate times into velocity calculations and sampling estimation.
- Preserve stable source-row provenance across sorting so downstream diagnostics and reproducible baselines can refer back to original rows.
- Make sampling-rate estimation and analyzer logic robust by computing intervals only from finite, strictly positive deltas and failing clearly when no valid interval remains.

### Description
- Added shared helpers in `ivt_filter/utils/sampling.py`: `SOURCE_ROW_ID_COLUMN`, `coerce_finite_timestamps`, `sort_by_time_with_source_row_id`, and `positive_timestamp_deltas` to validate timestamps, create/retain `source_row_id`, reject duplicates, and extract positive deltas.
- Updated `ivt_filter/processing/velocity_input.py::normalize_timestamps` to coerce and validate timestamp values, convert units, and call `sort_by_time_with_source_row_id` so provenance is stable after sorting, and updated `SamplingAnalyzer.analyze` to use `positive_timestamp_deltas` for interval calculation.
- Updated `ivt_filter/utils/sampling.py::estimate_sampling_rate` to use strictly positive deltas via `positive_timestamp_deltas` and raise a clear error when none remain.
- Applied the same validation/sorting policy to extraction by making `extractor.py::_sort_by_time` call `sort_by_time_with_source_row_id` and added an early return in `ivt_filter/processing/velocity_samples.py` to preserve empty-frame behavior before sampling analysis.
- Added regression tests in `tests/test_velocity_processing_components.py` covering unsorted input and `source_row_id` provenance, duplicate timestamps rejection, non-numeric/non-finite timestamp rejection, sampling-interval filtering, and consistent extractor behavior.

### Testing
- Ran targeted tests with `pytest -q tests/test_velocity_processing_components.py tests/test_velocity_internal_boundaries.py` and they passed completely.
- Ran the full test suite with `pytest -q` and the suite completed successfully with all tests passing (295 passed, 2 skipped).
- Verified compilation of modified modules with `python -m compileall` which completed without errors.