### PR TITLE
Gate tagged releases on reusable CI validation

### DIFF
--- a/.github/workflows/ContainerRegestry.yml
+++ b/.github/workflows/ContainerRegestry.yml
@@ -9,7 +9,11 @@ on:
       - 'v*.*.*'
 
 jobs:
+  checks:
+    uses: ./.github/workflows/main.yml
+
   build-and-push:
+    needs: checks
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,16 @@
 name: Python CI
 
 concurrency:
-  group: python-ci-${{ github.ref }}
+  group: python-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
-  push:          
-  pull_request:  
+  push:
+  pull_request:
+  workflow_call:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,19 +26,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
-      - name: Install dependencies
+      - name: Install package and pinned test tools
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-
-      - name: Install dev tools
-        run: |
-          pip install pytest-cov ruff mypy
+          python -m pip install --constraint constraints-dev.txt pytest pytest-cov
+          python -m pip install --editable .
 
       - name: Run tests with coverage
-        run: |
-          pytest -q --cov=ivt_filter --cov-report=term-missing --cov-report=xml --cov-fail-under=55
+        run: python -m pytest -q --cov=ivt_filter --cov-report=term-missing --cov-report=xml --cov-fail-under=58
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
@@ -45,10 +40,75 @@ jobs:
           name: coverage-xml-${{ matrix.python-version }}
           path: coverage.xml
 
-      - name: Lint (ruff, blocking on core)
-        run: |
-          ruff check ivt_filter
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - name: Install pinned lint tool
+        run: python -m pip install --constraint constraints-dev.txt ruff
+      - name: Lint package
+        run: ruff check ivt_filter
 
-      - name: Type check (mypy)
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - name: Install package and pinned type-check tool
         run: |
-          mypy ivt_filter
+          python -m pip install --constraint constraints-dev.txt mypy
+          python -m pip install --editable .
+      - name: Type check package
+        run: mypy ivt_filter
+
+  package-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - name: Install pinned build tool
+        run: python -m pip install --constraint constraints-dev.txt build
+      - name: Build distributions
+        run: python -m build
+      - name: Install wheel into isolated environment
+        run: |
+          python -m venv /tmp/ivt-wheel-smoke
+          /tmp/ivt-wheel-smoke/bin/python -m pip install dist/*.whl
+      - name: Verify installed wheel import and CLI
+        working-directory: /tmp
+        run: |
+          /tmp/ivt-wheel-smoke/bin/python -c "import ivt_filter"
+          /tmp/ivt-wheel-smoke/bin/python -m ivt_filter.cli --help
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-packages
+          path: dist/*
+
+  container-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build container
+        run: docker build --tag tobii-ivt-filter:smoke .
+      - name: Verify container CLI
+        run: docker run --rm tobii-ivt-filter:smoke --help
+      - name: Verify container package import
+        run: docker run --rm --entrypoint python tobii-ivt-filter:smoke -c "import ivt_filter"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,42 +5,32 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
+  checks:
+    uses: ./.github/workflows/main.yml
+
   publish:
+    needs: checks
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Install build tools
-        run: |
-          pip install --upgrade build twine
-
-      - name: Build distributions
-        run: |
-          python -m build
-
-      - name: Upload dists as artifact
-        uses: actions/upload-artifact@v4
+      - name: Download checked distributions
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
-          path: dist/*
+          path: dist
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          files: |
-            dist/*
+          files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -1,0 +1,8 @@
+# Exact versions for CI and local development tooling.
+# Install the tool you need with: python -m pip install --constraint constraints-dev.txt <tool>
+build==1.3.0
+mypy==1.20.2
+pytest==9.0.3
+pytest-cov==7.0.0
+ruff==0.15.12
+twine==6.2.0

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,25 @@
+# Protected `main` branch settings
+
+Configure a GitHub branch protection rule or repository ruleset for `main`. The release workflows rely on the tagged commit having passed the same reusable CI workflow, while branch protection keeps unreviewed commits from entering the release branch.
+
+## Pull request and push policy
+
+- Require a pull request before merging into `main`.
+- Require at least **one approving review**. Dismiss stale approvals when new commits are pushed.
+- Restrict updates to `main` so contributors cannot push directly. Apply the restriction to administrators and automation unless a deliberately scoped release or maintenance actor needs an exception.
+- Block force pushes and branch deletion.
+- Require branches to be up to date before merging so the required checks evaluate the exact merge candidate.
+
+## Required CI status checks
+
+Require every blocking job exposed by **Python CI**:
+
+- `test (3.10)`
+- `test (3.11)`
+- `test (3.12)`
+- `lint`
+- `type-check`
+- `package-build`
+- `container-smoke`
+
+The `package-build` job installs the generated wheel into an isolated virtual environment and runs the CLI from that installed artifact. The `container-smoke` job builds the image and verifies both its CLI and package import. Tagged PyPI releases and GHCR publication call the reusable Python CI workflow and cannot publish unless all of these checks succeed for the tagged commit.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pytest
 numpy 
 pandas 
 # Optional plotting: pip install tobii-ivt-filter[plot]

--- a/tests/test_ci_coverage_regressions.py
+++ b/tests/test_ci_coverage_regressions.py
@@ -1,0 +1,96 @@
+"""Coverage increments for timestamp, classifier-boundary, and experiment behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ivt_filter.config import IVTClassifierConfig, OlsenVelocityConfig
+from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+from ivt_filter.processing.classification import apply_ivt_classifier
+from ivt_filter.processing.velocity_input import normalize_timestamps
+
+
+def test_normalize_timestamps_converts_nanoseconds_sorts_copy_and_preserves_source() -> None:
+    source = pd.DataFrame({"clock_ns": [2_000_000.0, 1_000_000.0], "value": [2, 1]})
+
+    result = normalize_timestamps(
+        source, OlsenVelocityConfig(time_column="clock_ns", time_unit="ns")
+    )
+
+    assert result[["time_ms", "value"]].values.tolist() == [[1.0, 1.0], [2.0, 2.0]]
+    assert "time_ms" not in source.columns
+
+
+def test_normalize_timestamps_rejects_missing_configured_column() -> None:
+    with pytest.raises(ValueError, match="clock_us"):
+        normalize_timestamps(pd.DataFrame({"time_ms": [1.0]}), OlsenVelocityConfig(time_column="clock_us"))
+
+
+def test_classifier_threshold_is_inclusive_and_invalid_window_spike_needs_support() -> None:
+    cfg = IVTClassifierConfig(velocity_threshold_deg_per_sec=30.0)
+    source = pd.DataFrame(
+        {
+            "velocity_deg_per_sec": [29.999, 30.0, 100.0, 30.0],
+            "window_any_invalid": [False, False, True, True],
+        }
+    )
+
+    result = apply_ivt_classifier(source, cfg)
+
+    assert result["ivt_sample_type"].tolist() == ["Fixation", "Saccade", "Saccade", "Saccade"]
+    assert result["velocity_neighbor_support"].tolist() == [False, False, True, True]
+
+
+def test_classifier_invalid_window_rejects_isolated_velocity_spike() -> None:
+    result = apply_ivt_classifier(
+        pd.DataFrame(
+            {
+                "velocity_deg_per_sec": [1.0, 100.0, 1.0],
+                "window_any_invalid": [False, True, False],
+            }
+        )
+    )
+
+    assert result["ivt_sample_type"].tolist() == ["Fixation", "Fixation", "Fixation"]
+
+
+def _experiment(name: str, timestamp: datetime) -> ExperimentConfig:
+    return ExperimentConfig(
+        name=name,
+        description=f"Experiment {name}",
+        velocity_config=OlsenVelocityConfig(window_length_ms=20.0),
+        classifier_config=IVTClassifierConfig(velocity_threshold_deg_per_sec=30.0),
+        timestamp=timestamp,
+        tags=["tracked"],
+    )
+
+
+def test_experiment_manager_round_trips_results_metrics_and_best_configuration(tmp_path) -> None:
+    manager = ExperimentManager(str(tmp_path / "experiments"))
+    older = _experiment("older", datetime(2025, 1, 1, 12, 0, 0))
+    newer = _experiment("newer", datetime(2025, 1, 2, 12, 0, 0))
+    manager.save_experiment(older, metrics={"score": np.float64(0.5)})
+    manager.save_experiment(newer, pd.DataFrame({"velocity": [1.25]}), {"score": 0.75})
+
+    loaded_config, loaded_results, loaded_metrics = manager.load_experiment("newer")
+
+    assert loaded_config.to_dict() == newer.to_dict()
+    assert loaded_results is not None
+    assert loaded_results["velocity"].tolist() == [1.25]
+    assert loaded_metrics == {"score": 0.75}
+    assert [entry["name"] for entry in manager.list_experiments(tags=["tracked"])] == ["newer", "older"]
+    best_name, best_score, best_config = manager.get_best_configuration(metric="score")
+    assert (best_name, best_score, best_config.name) == ("newer", 0.75, "newer")
+
+
+def test_experiment_manager_reports_missing_experiment_and_metric(tmp_path) -> None:
+    manager = ExperimentManager(str(tmp_path / "experiments"))
+
+    with pytest.raises(ValueError, match="not found"):
+        manager.load_experiment("missing")
+    with pytest.raises(ValueError, match="No experiments found"):
+        manager.get_best_configuration(metric="missing")

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,56 @@
+"""Focused tests for Tobii archive extraction and native timestamp handling."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from extractor import TimestampUnitDetector, TobiiDataExtractor
+
+
+def test_timestamp_detector_accepts_ascii_microsecond_header() -> None:
+    detector = TimestampUnitDetector()
+    source = pd.DataFrame(columns=["Recording timestamp [ms]", "Eyetracker timestamp [us]"])
+
+    assert detector.detect_columns(source) == (
+        "Recording timestamp [ms]",
+        "Eyetracker timestamp [us]",
+    )
+
+
+def test_extract_filters_rows_sorts_by_recording_time_and_preserves_native_timestamps(
+    tmp_path,
+) -> None:
+    input_path = tmp_path / "raw.tsv"
+    output_path = tmp_path / "slim.tsv"
+    source = pd.DataFrame(
+        {
+            "Sensor": ["Eye Tracker", "Eye Tracker", "Mouse", "Eye Tracker", "Eye Tracker"],
+            "Event": ["", "", "", "Eyetracker Calibration", ""],
+            "Presented Stimulus name": ["Target", "Target", "Target", "Target", "  "],
+            "Recording timestamp [ms]": [20, 10, 5, 30, 40],
+            "Eyetracker timestamp [μs]": [20_123, 10_123, 5_123, 30_123, 40_123],
+            "Gaze point left X [DACS mm]": [2.0, 1.0, 0.5, 3.0, 4.0],
+        }
+    )
+    source.to_csv(input_path, sep="\t", index=False, decimal=",")
+
+    TobiiDataExtractor().extract(input_path, output_path)
+
+    result = pd.read_csv(output_path, sep="\t", decimal=",")
+    assert result["time_ms"].tolist() == [10, 20]
+    assert result["time_us"].tolist() == [10_123, 20_123]
+    assert result["gaze_left_x_mm"].tolist() == [1.0, 2.0]
+
+
+def test_extract_populates_missing_native_timestamp_columns(tmp_path) -> None:
+    input_path = tmp_path / "raw.tsv"
+    output_path = tmp_path / "slim.tsv"
+    pd.DataFrame({"Presented Stimulus name": ["Target"]}).to_csv(
+        input_path, sep="\t", index=False
+    )
+
+    TobiiDataExtractor().extract(input_path, output_path)
+
+    result = pd.read_csv(output_path, sep="\t", decimal=",")
+    assert result.columns[:2].tolist() == ["time_ms", "time_us"]
+    assert result[["time_ms", "time_us"]].isna().all().all()


### PR DESCRIPTION

- Refactor CI into a reusable Python CI workflow (`.github/workflows/main.yml`) that exposes separate jobs: `test` (3.10/3.11/3.12 matrix), `lint`, `type-check`, `package-build`, and `container-smoke`. The test job now installs pinned test tools via `constraints-dev.txt`. (`.github/workflows/main.yml`).
- Gate the PyPI release workflow and the GHCR/container publication workflow on the reusable CI checks so `release.yml` and `ContainerRegestry.yml` wait for `main.yml` to succeed for the tagged commit. (`.github/workflows/release.yml`, `.github/workflows/ContainerRegestry.yml`).
- Pin development tooling in `constraints-dev.txt` and stop shipping `pytest` as a runtime/container requirement by removing it from `requirements.txt`.
- Add a package-installation smoke test in CI: `package-build` creates distributions, installs the built wheel into an isolated virtualenv, verifies `import ivt_filter`, and runs the package CLI from the installed artifact; artifacts are uploaded and downloaded by the release job.
- Raise coverage enforcement from `55%` to `58%` and add focused tests: `tests/test_ci_coverage_regressions.py` (timestamp normalization, classifier boundary and invalid-window behavior, experiment manager round-trip and selection) and `tests/test_extractor.py` (native timestamp handling, filtering, sorting, missing timestamp columns).
- Document expected `main` branch protection settings and required CI checks in `docs/branch-protection.md`.

### Testing

- Ran `python -m pytest -q` against the test-suite: all tests passed locally (`291 passed, 2 skipped`).
- Ran `ruff check ivt_filter`: linter passed with no reported issues.
- Ran `mypy ivt_filter`: type checks completed with no reported issues.
- Parsed GitHub workflow YAMLs with a YAML loader to ensure valid workflow syntax: parsing succeeded for all modified workflow files.
- Verified repository hygiene with `git diff --cached --check`: no issues found.
- Note: building distributions and container smoke tests are exercised in the CI `package-build` and `container-smoke` jobs; local `python -m build` and Docker image builds could not be exercised end-to-end in this environment due to missing local build tooling and Docker, but the workflows perform those steps on `ubuntu-latest` in CI.
