### PR TITLE
Make Python and Docker dependency installs reproducible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
-FROM python:3.10-slim
+FROM python:3.10-slim@sha256:70f65c721aaddfb22b20ed6ec12606c59d9592493c5fcb6639f3d0e8ba3fbc10 AS builder
+
+WORKDIR /build
+
+COPY requirements/build.txt ./requirements/build.txt
+RUN pip install --no-cache-dir -r requirements/build.txt
+
+COPY pyproject.toml setup.py README.md ./
+COPY ivt_filter ./ivt_filter
+RUN pip wheel --no-cache-dir --no-deps --no-build-isolation --wheel-dir /wheels .
+
+FROM python:3.10-slim@sha256:70f65c721aaddfb22b20ed6ec12606c59d9592493c5fcb6639f3d0e8ba3fbc10
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-COPY requirements.txt ./
-RUN pip install --upgrade pip && pip install -r requirements.txt
+COPY requirements/runtime.txt ./requirements/runtime.txt
+RUN pip install --no-cache-dir -r requirements/runtime.txt
 
-# Copy source and install package
-COPY . .
-RUN pip install .
+COPY --from=builder /wheels/*.whl /tmp/wheels/
+RUN pip install --no-cache-dir --no-deps /tmp/wheels/*.whl && rm -rf /tmp/wheels
 
 # Default to the CLI; pass args at runtime
 ENTRYPOINT ["python", "-m", "ivt_filter.cli"]

--- a/README.md
+++ b/README.md
@@ -67,9 +67,8 @@ cd Tobii-I-VT-Filter-Reconstruction
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
-pip install --upgrade pip
-pip install -r requirements.txt
-pip install -e .
+pip install -r requirements/development.txt
+pip install --no-deps -e .
 ```
 
 Plotting is optional. Install the plotting extra only if you want to generate figures:
@@ -559,8 +558,8 @@ EOF
 Build a minimal runtime image and run the CLI inside the container.
 
 ```bash
-# Build locally
-docker build -t ivt-filter:latest .
+# Build locally (see docs/reproducibility.md for lock refresh instructions)
+docker build --pull=false -t ivt-filter:latest .
 
 # Run with a mounted data folder
 docker run --rm \

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,7 @@ Welcome to the I-VT Filter Reconstruction documentation!
 - **[README.md](../README.md)** - Main project documentation with installation, usage, and examples
 - **[QUICK_REFERENCE.md](QUICK_REFERENCE.md)** - Quick reference guide for common commands and configurations
 - **[TECHNICAL_SPECIFICATION.md](TECHNICAL_SPECIFICATION.md)** - Detailed technical specification of velocity calculation methods
+- **[reproducibility.md](reproducibility.md)** - Locked dependencies and reproducible Docker build procedure
 
 ## Documentation Structure
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,71 @@
+# Reproducible dependency and Docker builds
+
+Package metadata has one authoritative source: `pyproject.toml`. It declares the
+supported Python versions, the minimal runtime dependencies, and optional extras.
+The `plot` extra installs Matplotlib only when figures are needed, and the
+`parallel` extra installs Joblib only when optional parallel processing is
+needed. Neither optional dependency is installed in the minimal runtime image.
+
+The dependency files under `requirements/` separate build, runtime, and development
+concerns. The resolved runtime and development lock files are generated for Python
+3.10, matching the Docker base image:
+
+- `requirements/build.txt` pins the build tools installed only in the Docker
+  builder stage. Keep these pins synchronized with `[build-system].requires` in
+  `pyproject.toml`.
+- `requirements/runtime.txt` locks only the default runtime dependency graph.
+- `requirements/development.txt` locks the default dependency graph plus the
+  `development` extra, including pytest for local test runs.
+
+## Refreshing dependency locks
+
+Install [uv](https://docs.astral.sh/uv/) and regenerate both lock files from the
+repository root whenever dependency metadata changes or dependencies should be
+updated:
+
+```bash
+uv pip compile pyproject.toml \
+  --output-file requirements/runtime.txt \
+  --python-version 3.10
+uv pip compile pyproject.toml \
+  --extra development \
+  --output-file requirements/development.txt \
+  --python-version 3.10
+```
+
+Review the resulting diff and run the test suite after every refresh. For local
+development, install the locked development dependency set before installing the
+editable package without a second dependency-resolution pass:
+
+```bash
+python -m pip install -r requirements/development.txt
+python -m pip install --no-deps -e .
+pytest
+```
+
+Optional features should be installed explicitly when needed. For example, use
+`python -m pip install -e '.[plot]'` for plotting or
+`python -m pip install -e '.[parallel]'` for parallel processing. These commands
+resolve the requested optional dependency at install time; add a dedicated lock
+file if a reproducibly pinned optional environment is required.
+
+## Building the runtime image
+
+The Dockerfile pins the Python base image by digest in both stages. The builder
+stage installs the pinned tools from `requirements/build.txt` and creates a wheel
+without build isolation or dependency resolution. The final stage installs
+`requirements/runtime.txt`, then installs that wheel with dependency resolution
+disabled. It intentionally does not upgrade pip during the build and does not
+install pytest, Matplotlib, Joblib, setuptools, or wheel into the final image.
+
+Use this exact build command from the repository root:
+
+```bash
+docker build --pull=false -t ivt-filter:latest .
+```
+
+When intentionally updating the base image, resolve the current digest for the
+chosen Python tag, update the digest in `Dockerfile`, rebuild the image, and run
+the test suite. Keeping `--pull=false` in the documented build command makes it
+clear that routine builds consume the reviewed digest rather than refreshing a
+mutable tag implicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,40 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools==80.9.0", "wheel==0.45.1"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "tobii-ivt-filter"
+version = "0.1.0"
+description = "From-scratch Python implementation of Tobii's I-VT velocity-threshold filter"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "cemGr" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "numpy>=1.21",
+    "pandas>=1.3",
+]
+
+[project.urls]
+Homepage = "https://github.com/cemGr/Tobii-I-VT-Filter-Reconstruction"
+
+[project.optional-dependencies]
+plot = [
+    "matplotlib>=3.5",
+]
+parallel = [
+    "joblib>=1.1",
+]
+development = [
+    "pytest>=8.4,<9",
+]
+
+[tool.setuptools.packages.find]
+exclude = ["tests", "examples", "experiments", "notebooks"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-pytest
-numpy 
-pandas 
-# Optional plotting: pip install tobii-ivt-filter[plot]
-joblib  # Optional: for parallel processing (recommended for large datasets)

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,4 @@
+# Keep these pins synchronized with [build-system].requires in pyproject.toml.
+# They are installed only in the Docker builder stage.
+setuptools==80.9.0
+wheel==0.45.1

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,0 +1,34 @@
+# Refresh this lock file with:
+#    uv pip compile pyproject.toml --extra development --output-file requirements/development.txt --python-version 3.10
+#
+# Do not edit dependency pins by hand.
+exceptiongroup==1.3.1 ; python_full_version < '3.11'
+    # via pytest
+iniconfig==2.1.0
+    # via pytest
+numpy==2.2.6
+    # via
+    #   pandas
+    #   tobii-ivt-filter (pyproject.toml)
+packaging==25.0
+    # via pytest
+pandas==2.3.3
+    # via tobii-ivt-filter (pyproject.toml)
+pluggy==1.6.0
+    # via pytest
+pygments==2.19.2
+    # via pytest
+pytest==8.4.2
+    # via tobii-ivt-filter (pyproject.toml)
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2025.2
+    # via pandas
+six==1.17.0
+    # via python-dateutil
+tomli==2.3.0 ; python_full_version < '3.11'
+    # via pytest
+typing-extensions==4.15.0 ; python_full_version < '3.11'
+    # via exceptiongroup
+tzdata==2025.3
+    # via pandas

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,0 +1,18 @@
+# Refresh this lock file with:
+#    uv pip compile pyproject.toml --output-file requirements/runtime.txt --python-version 3.10
+#
+# Do not edit dependency pins by hand.
+numpy==2.2.6
+    # via
+    #   pandas
+    #   tobii-ivt-filter (pyproject.toml)
+pandas==2.3.3
+    # via tobii-ivt-filter (pyproject.toml)
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2025.2
+    # via pandas
+six==1.17.0
+    # via python-dateutil
+tzdata==2025.3
+    # via pandas

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,6 @@
-# setup.py
-from pathlib import Path
-from setuptools import setup, find_packages
+"""Compatibility shim for tools that still expect a setup.py file."""
 
-README = Path(__file__).with_name("README.md").read_text(encoding="utf-8")
+from setuptools import setup
 
-setup(
-    name="tobii-ivt-filter",
-    version="0.1.0",
-    description="From-scratch Python implementation of Tobii's I-VT velocity-threshold filter",
-    long_description=README,
-    long_description_content_type="text/markdown",
-    author="cemGr",
-    url="https://github.com/cemGr/Tobii-I-VT-Filter-Reconstruction",
-    license="MIT",
-    packages=find_packages(exclude=("tests", "examples", "experiments", "notebooks")),
-    python_requires=">=3.10",
-    install_requires=[
-        "numpy>=1.21",
-        "pandas>=1.3",
-    ],
-    extras_require={
-        "plot": ["matplotlib>=3.5"],
-        "parallel": ["joblib>=1.1"],
-    },
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-)
+
+setup()


### PR DESCRIPTION
### Motivation
- Ensure a single authoritative source for package metadata and supported Python versions to avoid drift between `setup.py`, `requirements.txt`, and other files. 
- Produce reproducible, pinned dependency sets for runtime, build, and development environments so container images and local dev installs do not pull unexpected packages. 
- Keep the runtime Docker image minimal by excluding test and optional plotting/parallel dependencies and by pinning the base image by digest.

### Description
- Consolidated package metadata into `pyproject.toml` and reduced `setup.py` to a compatibility shim; declared runtime deps and optional extras (`plot`, `parallel`, `development`) in `[project]` and `[project.optional-dependencies]`.
- Added pinned lock files: `requirements/build.txt` (pinned build tools), `requirements/runtime.txt` (locked runtime graph), and `requirements/development.txt` (locked dev graph with `pytest`), and removed the unscoped `requirements.txt`.
- Rewrote `Dockerfile` as a two-stage build that pins `python:3.10-slim` by digest, installs pinned build tools in a builder stage to produce a wheel, and installs only `requirements/runtime.txt` plus the prebuilt wheel in the final stage; removed the unconditional `pip install --upgrade pip` and avoided installing `pytest`, `matplotlib`, `joblib`, `setuptools`, or `wheel` into the runtime image.
- Added `docs/reproducibility.md` documenting the `uv pip compile` lock refresh commands and the precise reproducible Docker build command (`docker build --pull=false -t ivt-filter:latest .`), and updated `README.md` and `docs/INDEX.md` to reference the new workflow.

### Testing
- Ran an automated packaging/structure validation script that verifies `pyproject.toml` metadata, synchronization of build-tool pins, absence of dev/optional packages from the runtime lock, and Dockerfile policy checks, which passed. 
- Ran the test suite with `pytest`, which completed successfully with `282 passed, 2 skipped`. 
- Ran automated whitespace and staged diff checks (`git diff --cached --check`) before commit, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd0529c7c8323a2202ccaf91e4887)