### PR TITLE
Revamp CI workflows, pin dev tools, enforce recording timestamp in extractor, and add tests/docs

### DIFF
--- a/.github/workflows/ContainerRegestry.yml
+++ b/.github/workflows/ContainerRegestry.yml
@@ -9,7 +9,11 @@ on:
       - 'v*.*.*'
 
 jobs:
+  checks:
+    uses: ./.github/workflows/main.yml
+
   build-and-push:
+    needs: checks
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,16 @@
 name: Python CI
 
 concurrency:
-  group: python-ci-${{ github.ref }}
+  group: python-ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
-  push:          
-  pull_request:  
+  push:
+  pull_request:
+  workflow_call:
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,19 +26,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
-      - name: Install dependencies
+      - name: Install package and pinned test tools
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-
-      - name: Install dev tools
-        run: |
-          pip install pytest-cov ruff mypy
+          python -m pip install --constraint constraints-dev.txt pytest pytest-cov
+          python -m pip install --editable .
 
       - name: Run tests with coverage
-        run: |
-          pytest -q --cov=ivt_filter --cov-report=term-missing --cov-report=xml --cov-fail-under=55
+        run: python -m pytest -q --cov=ivt_filter --cov-report=term-missing --cov-report=xml --cov-fail-under=58
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
@@ -45,10 +40,75 @@ jobs:
           name: coverage-xml-${{ matrix.python-version }}
           path: coverage.xml
 
-      - name: Lint (ruff, blocking on core)
-        run: |
-          ruff check ivt_filter
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - name: Install pinned lint tool
+        run: python -m pip install --constraint constraints-dev.txt ruff
+      - name: Lint package
+        run: ruff check ivt_filter
 
-      - name: Type check (mypy)
+  type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - name: Install package and pinned type-check tool
         run: |
-          mypy ivt_filter
+          python -m pip install --constraint constraints-dev.txt mypy
+          python -m pip install --editable .
+      - name: Type check package
+        run: mypy ivt_filter
+
+  package-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: "pip"
+      - name: Install pinned build tool
+        run: python -m pip install --constraint constraints-dev.txt build
+      - name: Build distributions
+        run: python -m build
+      - name: Install wheel into isolated environment
+        run: |
+          python -m venv /tmp/ivt-wheel-smoke
+          /tmp/ivt-wheel-smoke/bin/python -m pip install dist/*.whl
+      - name: Verify installed wheel import and CLI
+        working-directory: /tmp
+        run: |
+          /tmp/ivt-wheel-smoke/bin/python -c "import ivt_filter"
+          /tmp/ivt-wheel-smoke/bin/python -m ivt_filter.cli --help
+      - name: Upload distributions
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-packages
+          path: dist/*
+
+  container-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build container
+        run: docker build --tag tobii-ivt-filter:smoke .
+      - name: Verify container CLI
+        run: docker run --rm tobii-ivt-filter:smoke --help
+      - name: Verify container package import
+        run: docker run --rm --entrypoint python tobii-ivt-filter:smoke -c "import ivt_filter"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,42 +5,32 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+
 jobs:
+  checks:
+    uses: ./.github/workflows/main.yml
+
   publish:
+    needs: checks
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Install build tools
-        run: |
-          pip install --upgrade build twine
-
-      - name: Build distributions
-        run: |
-          python -m build
-
-      - name: Upload dists as artifact
-        uses: actions/upload-artifact@v4
+      - name: Download checked distributions
+        uses: actions/download-artifact@v4
         with:
           name: dist-packages
-          path: dist/*
+          path: dist
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          files: |
-            dist/*
+          files: dist/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.13.0
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -1,0 +1,8 @@
+# Exact versions for CI and local development tooling.
+# Install the tool you need with: python -m pip install --constraint constraints-dev.txt <tool>
+build==1.3.0
+mypy==1.20.2
+pytest==9.0.3
+pytest-cov==7.0.0
+ruff==0.15.12
+twine==6.2.0

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,25 @@
+# Protected `main` branch settings
+
+Configure a GitHub branch protection rule or repository ruleset for `main`. The release workflows rely on the tagged commit having passed the same reusable CI workflow, while branch protection keeps unreviewed commits from entering the release branch.
+
+## Pull request and push policy
+
+- Require a pull request before merging into `main`.
+- Require at least **one approving review**. Dismiss stale approvals when new commits are pushed.
+- Restrict updates to `main` so contributors cannot push directly. Apply the restriction to administrators and automation unless a deliberately scoped release or maintenance actor needs an exception.
+- Block force pushes and branch deletion.
+- Require branches to be up to date before merging so the required checks evaluate the exact merge candidate.
+
+## Required CI status checks
+
+Require every blocking job exposed by **Python CI**:
+
+- `test (3.10)`
+- `test (3.11)`
+- `test (3.12)`
+- `lint`
+- `type-check`
+- `package-build`
+- `container-smoke`
+
+The `package-build` job installs the generated wheel into an isolated virtual environment and runs the CLI from that installed artifact. The `container-smoke` job builds the image and verifies both its CLI and package import. Tagged PyPI releases and GHCR publication call the reusable Python CI workflow and cannot publish unless all of these checks succeed for the tagged commit.

--- a/extractor.py
+++ b/extractor.py
@@ -200,13 +200,12 @@ class TobiiDataExtractor:
         """
         recording_col, eyetracker_col = self.timestamp_detector.detect_columns(source)
 
-        # Extract time_ms from Recording timestamp [ms]
-        if recording_col is not None:
-            target["time_ms"] = source[recording_col].copy()
-            print(f"[Extractor] Using Recording timestamp [ms] for time_ms")
-        else:
-            print("[Extractor] Warning: Recording timestamp [ms] not found")
-            target["time_ms"] = pd.NA
+        # Extract required time_ms from Recording timestamp [ms]. Without it,
+        # the slim export cannot be sorted or consumed by the IVT pipeline.
+        if recording_col is None:
+            raise ValueError("Recording timestamp [ms] column not found")
+        target["time_ms"] = source[recording_col].copy()
+        print("[Extractor] Using Recording timestamp [ms] for time_ms")
 
         # Extract time_us from Eyetracker timestamp [μs]
         if eyetracker_col is not None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pytest
 numpy 
 pandas 
 # Optional plotting: pip install tobii-ivt-filter[plot]

--- a/tests/test_ci_coverage_regressions.py
+++ b/tests/test_ci_coverage_regressions.py
@@ -1,0 +1,96 @@
+"""Coverage increments for timestamp, classifier-boundary, and experiment behavior."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from ivt_filter.config import IVTClassifierConfig, OlsenVelocityConfig
+from ivt_filter.evaluation.experiment import ExperimentConfig, ExperimentManager
+from ivt_filter.processing.classification import apply_ivt_classifier
+from ivt_filter.processing.velocity_input import normalize_timestamps
+
+
+def test_normalize_timestamps_converts_nanoseconds_sorts_copy_and_preserves_source() -> None:
+    source = pd.DataFrame({"clock_ns": [2_000_000.0, 1_000_000.0], "value": [2, 1]})
+
+    result = normalize_timestamps(
+        source, OlsenVelocityConfig(time_column="clock_ns", time_unit="ns")
+    )
+
+    assert result[["time_ms", "value"]].values.tolist() == [[1.0, 1.0], [2.0, 2.0]]
+    assert "time_ms" not in source.columns
+
+
+def test_normalize_timestamps_rejects_missing_configured_column() -> None:
+    with pytest.raises(ValueError, match="clock_us"):
+        normalize_timestamps(pd.DataFrame({"time_ms": [1.0]}), OlsenVelocityConfig(time_column="clock_us"))
+
+
+def test_classifier_threshold_is_inclusive_and_invalid_window_spike_needs_support() -> None:
+    cfg = IVTClassifierConfig(velocity_threshold_deg_per_sec=30.0)
+    source = pd.DataFrame(
+        {
+            "velocity_deg_per_sec": [29.999, 30.0, 100.0, 30.0],
+            "window_any_invalid": [False, False, True, True],
+        }
+    )
+
+    result = apply_ivt_classifier(source, cfg)
+
+    assert result["ivt_sample_type"].tolist() == ["Fixation", "Saccade", "Saccade", "Saccade"]
+    assert result["velocity_neighbor_support"].tolist() == [False, False, True, True]
+
+
+def test_classifier_invalid_window_rejects_isolated_velocity_spike() -> None:
+    result = apply_ivt_classifier(
+        pd.DataFrame(
+            {
+                "velocity_deg_per_sec": [1.0, 100.0, 1.0],
+                "window_any_invalid": [False, True, False],
+            }
+        )
+    )
+
+    assert result["ivt_sample_type"].tolist() == ["Fixation", "Fixation", "Fixation"]
+
+
+def _experiment(name: str, timestamp: datetime) -> ExperimentConfig:
+    return ExperimentConfig(
+        name=name,
+        description=f"Experiment {name}",
+        velocity_config=OlsenVelocityConfig(window_length_ms=20.0),
+        classifier_config=IVTClassifierConfig(velocity_threshold_deg_per_sec=30.0),
+        timestamp=timestamp,
+        tags=["tracked"],
+    )
+
+
+def test_experiment_manager_round_trips_results_metrics_and_best_configuration(tmp_path) -> None:
+    manager = ExperimentManager(str(tmp_path / "experiments"))
+    older = _experiment("older", datetime(2025, 1, 1, 12, 0, 0))
+    newer = _experiment("newer", datetime(2025, 1, 2, 12, 0, 0))
+    manager.save_experiment(older, metrics={"score": np.float64(0.5)})
+    manager.save_experiment(newer, pd.DataFrame({"velocity": [1.25]}), {"score": 0.75})
+
+    loaded_config, loaded_results, loaded_metrics = manager.load_experiment("newer")
+
+    assert loaded_config.to_dict() == newer.to_dict()
+    assert loaded_results is not None
+    assert loaded_results["velocity"].tolist() == [1.25]
+    assert loaded_metrics == {"score": 0.75}
+    assert [entry["name"] for entry in manager.list_experiments(tags=["tracked"])] == ["newer", "older"]
+    best_name, best_score, best_config = manager.get_best_configuration(metric="score")
+    assert (best_name, best_score, best_config.name) == ("newer", 0.75, "newer")
+
+
+def test_experiment_manager_reports_missing_experiment_and_metric(tmp_path) -> None:
+    manager = ExperimentManager(str(tmp_path / "experiments"))
+
+    with pytest.raises(ValueError, match="not found"):
+        manager.load_experiment("missing")
+    with pytest.raises(ValueError, match="No experiments found"):
+        manager.get_best_configuration(metric="missing")

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,73 @@
+"""Focused tests for Tobii archive extraction and native timestamp handling."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from extractor import TimestampUnitDetector, TobiiDataExtractor
+
+
+def test_timestamp_detector_accepts_ascii_microsecond_header() -> None:
+    detector = TimestampUnitDetector()
+    source = pd.DataFrame(columns=["Recording timestamp [ms]", "Eyetracker timestamp [us]"])
+
+    assert detector.detect_columns(source) == (
+        "Recording timestamp [ms]",
+        "Eyetracker timestamp [us]",
+    )
+
+
+def test_extract_filters_rows_sorts_by_recording_time_and_preserves_native_timestamps(
+    tmp_path,
+) -> None:
+    input_path = tmp_path / "raw.tsv"
+    output_path = tmp_path / "slim.tsv"
+    source = pd.DataFrame(
+        {
+            "Sensor": ["Eye Tracker", "Eye Tracker", "Mouse", "Eye Tracker", "Eye Tracker"],
+            "Event": ["", "", "", "Eyetracker Calibration", ""],
+            "Presented Stimulus name": ["Target", "Target", "Target", "Target", "  "],
+            "Recording timestamp [ms]": [20, 10, 5, 30, 40],
+            "Eyetracker timestamp [μs]": [20_123, 10_123, 5_123, 30_123, 40_123],
+            "Gaze point left X [DACS mm]": [2.0, 1.0, 0.5, 3.0, 4.0],
+        }
+    )
+    source.to_csv(input_path, sep="\t", index=False, decimal=",")
+
+    TobiiDataExtractor().extract(input_path, output_path)
+
+    result = pd.read_csv(output_path, sep="\t", decimal=",")
+    assert result["time_ms"].tolist() == [10, 20]
+    assert result["time_us"].tolist() == [10_123, 20_123]
+    assert result["gaze_left_x_mm"].tolist() == [1.0, 2.0]
+
+
+def test_extract_rejects_missing_recording_timestamp_column(tmp_path) -> None:
+    input_path = tmp_path / "raw.tsv"
+    output_path = tmp_path / "slim.tsv"
+    pd.DataFrame({"Presented Stimulus name": ["Target"]}).to_csv(
+        input_path, sep="\t", index=False
+    )
+
+    with pytest.raises(ValueError, match=r"Recording timestamp \[ms\] column not found"):
+        TobiiDataExtractor().extract(input_path, output_path)
+
+    assert not output_path.exists()
+
+
+def test_extract_keeps_microsecond_timestamp_optional(tmp_path) -> None:
+    input_path = tmp_path / "raw.tsv"
+    output_path = tmp_path / "slim.tsv"
+    pd.DataFrame(
+        {
+            "Presented Stimulus name": ["Target"],
+            "Recording timestamp [ms]": [12],
+        }
+    ).to_csv(input_path, sep="\t", index=False)
+
+    TobiiDataExtractor().extract(input_path, output_path)
+
+    result = pd.read_csv(output_path, sep="\t", decimal=",")
+    assert result["time_ms"].tolist() == [12]
+    assert result["time_us"].isna().all()


### PR DESCRIPTION
### Motivation

- Make CI reusable, more comprehensive, and deterministic by splitting checks into focused jobs and reusing the Python CI workflow from other publishing pipelines.  
- Pin development and CI tooling to exact versions to reduce toolchain flakiness and ensure reproducible runs.  
- Harden data extraction by requiring the Recording timestamp column so downstream IVT processing cannot receive unsortable data.  

### Description

- Replace the single monolithic `main.yml` job with multiple jobs (`test`, `lint`, `type-check`, `package-build`, `container-smoke`) and expose it as a reusable workflow called by `release.yml` and `ContainerRegestry.yml`, plus tighten concurrency grouping.  
- Add `constraints-dev.txt` with pinned versions for `build`, `mypy`, `pytest`, `pytest-cov`, `ruff`, and `twine`, and update CI steps to install tools via the constraints file and `python -m pip install --editable .`.  
- Raise the test coverage gate to `58` and adjust test invocation to run `python -m pytest`, add a dedicated lint step using `ruff`, type checking with `mypy`, wheel build & smoke install using `python -m build`, and a container smoke job that runs `docker build` and verifies the CLI and package import.  
- Update `release.yml` to download the `dist-packages` artifact from the reusable CI, use `softprops/action-gh-release@v2`, and bump the PyPI publish action to `pypa/gh-action-pypi-publish@v1.13.0`; update `ContainerRegestry.yml` to require the `checks` job before building.  
- Enforce presence of the Recording timestamp in `TobiiDataExtractor._convert_timestamps` by raising `ValueError` when the column is missing.  
- Add `constraints-dev.txt`, `docs/branch-protection.md` describing required checks to protect `main`, and new unit tests in `tests/test_extractor.py` and `tests/test_ci_coverage_regressions.py` exercising timestamp detection, extraction behavior, timestamp normalization, classifier rules, and the experiment manager.  
- Remove `pytest` from `requirements.txt` to avoid pinning test tools in runtime requirements.  

### Testing

- Ran the full CI matrix: `python -m pytest` across Python 3.10, 3.11, and 3.12 with coverage reporting and the new `--cov-fail-under=58` gate, and the test suite completed successfully.  
- Executed linting with `ruff check ivt_filter` and static type checking with `mypy ivt_filter`, which both passed in their jobs.  
- Performed artifact packaging with `python -m build`, installed the built wheel in an isolated venv and executed the CLI `python -m ivt_filter.cli --help`, and ran container smoke tests using `docker build` and `docker run`, all of which succeeded.
