### PR TITLE
Reproducible builds: add locked reqs, multi-stage Docker, and CI/dev workflow changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,16 +24,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+          cache-dependency-path: requirements/development.txt
 
-      - name: Install dependencies
+      - name: Install locked development dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install -e .
-
-      - name: Install dev tools
-        run: |
-          pip install pytest-cov ruff mypy
+          python -m pip install -r requirements/development.txt
+          python -m pip install --no-deps -e .
 
       - name: Run tests with coverage
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,26 @@
-FROM python:3.10-slim
+FROM python:3.10-slim@sha256:70f65c721aaddfb22b20ed6ec12606c59d9592493c5fcb6639f3d0e8ba3fbc10 AS builder
+
+WORKDIR /build
+
+COPY requirements/build.txt ./requirements/build.txt
+RUN pip install --no-cache-dir -r requirements/build.txt
+
+COPY pyproject.toml setup.py README.md ./
+COPY ivt_filter ./ivt_filter
+RUN pip wheel --no-cache-dir --no-deps --no-build-isolation --wheel-dir /wheels .
+
+FROM python:3.10-slim@sha256:70f65c721aaddfb22b20ed6ec12606c59d9592493c5fcb6639f3d0e8ba3fbc10
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 
 WORKDIR /app
 
-COPY requirements.txt ./
-RUN pip install --upgrade pip && pip install -r requirements.txt
+COPY requirements/runtime.txt ./requirements/runtime.txt
+RUN pip install --no-cache-dir -r requirements/runtime.txt
 
-# Copy source and install package
-COPY . .
-RUN pip install .
+COPY --from=builder /wheels/*.whl /tmp/wheels/
+RUN pip install --no-cache-dir --no-deps /tmp/wheels/*.whl && rm -rf /tmp/wheels
 
 # Default to the CLI; pass args at runtime
 ENTRYPOINT ["python", "-m", "ivt_filter.cli"]

--- a/README.md
+++ b/README.md
@@ -67,9 +67,8 @@ cd Tobii-I-VT-Filter-Reconstruction
 python -m venv .venv
 source .venv/bin/activate  # On Windows: .venv\Scripts\activate
 
-pip install --upgrade pip
-pip install -r requirements.txt
-pip install -e .
+pip install -r requirements/development.txt
+pip install --no-deps -e .
 ```
 
 Plotting is optional. Install the plotting extra only if you want to generate figures:
@@ -559,8 +558,8 @@ EOF
 Build a minimal runtime image and run the CLI inside the container.
 
 ```bash
-# Build locally
-docker build -t ivt-filter:latest .
+# Build locally (see docs/reproducibility.md for lock refresh instructions)
+docker build --pull=false -t ivt-filter:latest .
 
 # Run with a mounted data folder
 docker run --rm \

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,6 +7,7 @@ Welcome to the I-VT Filter Reconstruction documentation!
 - **[README.md](../README.md)** - Main project documentation with installation, usage, and examples
 - **[QUICK_REFERENCE.md](QUICK_REFERENCE.md)** - Quick reference guide for common commands and configurations
 - **[TECHNICAL_SPECIFICATION.md](TECHNICAL_SPECIFICATION.md)** - Detailed technical specification of velocity calculation methods
+- **[reproducibility.md](reproducibility.md)** - Locked dependencies and reproducible Docker build procedure
 
 ## Documentation Structure
 

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,72 @@
+# Reproducible dependency and Docker builds
+
+Package metadata has one authoritative source: `pyproject.toml`. It declares the
+supported Python versions, the minimal runtime dependencies, and optional extras.
+The `plot` extra installs Matplotlib only when figures are needed, and the
+`parallel` extra installs Joblib only when optional parallel processing is
+needed. Neither optional dependency is installed in the minimal runtime image.
+
+The dependency files under `requirements/` separate build, runtime, and development
+concerns. The resolved runtime and development lock files are generated for Python
+3.10, matching the Docker base image:
+
+- `requirements/build.txt` pins the build tools installed only in the Docker
+  builder stage. Keep these pins synchronized with `[build-system].requires` in
+  `pyproject.toml`.
+- `requirements/runtime.txt` locks only the default runtime dependency graph.
+- `requirements/development.txt` locks the default dependency graph plus the
+  `development` extra, including pytest, coverage support, Ruff, and mypy for
+  local checks and CI runs.
+
+## Refreshing dependency locks
+
+Install [uv](https://docs.astral.sh/uv/) and regenerate both lock files from the
+repository root whenever dependency metadata changes or dependencies should be
+updated:
+
+```bash
+uv pip compile pyproject.toml \
+  --output-file requirements/runtime.txt \
+  --python-version 3.10
+uv pip compile pyproject.toml \
+  --extra development \
+  --output-file requirements/development.txt \
+  --python-version 3.10
+```
+
+Review the resulting diff and run the test suite after every refresh. For local
+development, install the locked development dependency set before installing the
+editable package without a second dependency-resolution pass:
+
+```bash
+python -m pip install -r requirements/development.txt
+python -m pip install --no-deps -e .
+pytest
+```
+
+Optional features should be installed explicitly when needed. For example, use
+`python -m pip install -e '.[plot]'` for plotting or
+`python -m pip install -e '.[parallel]'` for parallel processing. These commands
+resolve the requested optional dependency at install time; add a dedicated lock
+file if a reproducibly pinned optional environment is required.
+
+## Building the runtime image
+
+The Dockerfile pins the Python base image by digest in both stages. The builder
+stage installs the pinned tools from `requirements/build.txt` and creates a wheel
+without build isolation or dependency resolution. The final stage installs
+`requirements/runtime.txt`, then installs that wheel with dependency resolution
+disabled. It intentionally does not upgrade pip during the build and does not
+install pytest, Matplotlib, Joblib, setuptools, or wheel into the final image.
+
+Use this exact build command from the repository root:
+
+```bash
+docker build --pull=false -t ivt-filter:latest .
+```
+
+When intentionally updating the base image, resolve the current digest for the
+chosen Python tag, update the digest in `Dockerfile`, rebuild the image, and run
+the test suite. Keeping `--pull=false` in the documented build command makes it
+clear that routine builds consume the reviewed digest rather than refreshing a
+mutable tag implicitly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,43 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools==80.9.0", "wheel==0.45.1"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "tobii-ivt-filter"
+version = "0.1.0"
+description = "From-scratch Python implementation of Tobii's I-VT velocity-threshold filter"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "cemGr" },
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+dependencies = [
+    "numpy>=1.21",
+    "pandas>=1.3",
+]
+
+[project.urls]
+Homepage = "https://github.com/cemGr/Tobii-I-VT-Filter-Reconstruction"
+
+[project.optional-dependencies]
+plot = [
+    "matplotlib>=3.5",
+]
+parallel = [
+    "joblib>=1.1",
+]
+development = [
+    "mypy>=1.20,<2",
+    "pytest>=8.4,<9",
+    "pytest-cov>=7.1,<8",
+    "ruff>=0.15,<0.16",
+]
+
+[tool.setuptools.packages.find]
+exclude = ["tests", "examples", "experiments", "notebooks"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-pytest
-numpy 
-pandas 
-# Optional plotting: pip install tobii-ivt-filter[plot]
-joblib  # Optional: for parallel processing (recommended for large datasets)

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,0 +1,4 @@
+# Keep these pins synchronized with [build-system].requires in pyproject.toml.
+# They are installed only in the Docker builder stage.
+setuptools==80.9.0
+wheel==0.45.1

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,0 +1,52 @@
+# Refresh this lock file with:
+#    uv pip compile pyproject.toml --extra development --output-file requirements/development.txt --python-version 3.10
+#
+# Do not edit dependency pins by hand.
+coverage==7.13.4
+    # via pytest-cov
+exceptiongroup==1.3.1 ; python_full_version < '3.11'
+    # via pytest
+iniconfig==2.1.0
+    # via pytest
+librt==0.9.0 ; platform_python_implementation != 'PyPy'
+    # via mypy
+mypy==1.20.2
+    # via tobii-ivt-filter (pyproject.toml)
+mypy-extensions==1.1.0
+    # via mypy
+numpy==2.2.6
+    # via
+    #   pandas
+    #   tobii-ivt-filter (pyproject.toml)
+packaging==25.0
+    # via pytest
+pandas==2.3.3
+    # via tobii-ivt-filter (pyproject.toml)
+pathspec==1.1.0
+    # via mypy
+pluggy==1.6.0
+    # via pytest
+pygments==2.19.2
+    # via pytest
+pytest==8.4.2
+    # via
+    #   pytest-cov
+    #   tobii-ivt-filter (pyproject.toml)
+pytest-cov==7.1.0
+    # via tobii-ivt-filter (pyproject.toml)
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2025.2
+    # via pandas
+ruff==0.15.15
+    # via tobii-ivt-filter (pyproject.toml)
+six==1.17.0
+    # via python-dateutil
+tomli==2.3.0 ; python_full_version < '3.11'
+    # via pytest
+typing-extensions==4.15.0
+    # via
+    #   exceptiongroup
+    #   mypy
+tzdata==2025.3
+    # via pandas

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,0 +1,18 @@
+# Refresh this lock file with:
+#    uv pip compile pyproject.toml --output-file requirements/runtime.txt --python-version 3.10
+#
+# Do not edit dependency pins by hand.
+numpy==2.2.6
+    # via
+    #   pandas
+    #   tobii-ivt-filter (pyproject.toml)
+pandas==2.3.3
+    # via tobii-ivt-filter (pyproject.toml)
+python-dateutil==2.9.0.post0
+    # via pandas
+pytz==2025.2
+    # via pandas
+six==1.17.0
+    # via python-dateutil
+tzdata==2025.3
+    # via pandas

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,6 @@
-# setup.py
-from pathlib import Path
-from setuptools import setup, find_packages
+"""Compatibility shim for tools that still expect a setup.py file."""
 
-README = Path(__file__).with_name("README.md").read_text(encoding="utf-8")
+from setuptools import setup
 
-setup(
-    name="tobii-ivt-filter",
-    version="0.1.0",
-    description="From-scratch Python implementation of Tobii's I-VT velocity-threshold filter",
-    long_description=README,
-    long_description_content_type="text/markdown",
-    author="cemGr",
-    url="https://github.com/cemGr/Tobii-I-VT-Filter-Reconstruction",
-    license="MIT",
-    packages=find_packages(exclude=("tests", "examples", "experiments", "notebooks")),
-    python_requires=">=3.10",
-    install_requires=[
-        "numpy>=1.21",
-        "pandas>=1.3",
-    ],
-    extras_require={
-        "plot": ["matplotlib>=3.5"],
-        "parallel": ["joblib>=1.1"],
-    },
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-)
+
+setup()


### PR DESCRIPTION
### Motivation
- Ensure reproducible builds and deterministic images by pinning build/runtime/development dependencies and documenting the process. 
- Reduce final image size and remove unnecessary dev tooling from the runtime image by using a multi-stage Docker build. 
- Standardize local development and CI installs on a single locked development dependency set to avoid double dependency resolution. 

### Description
- Add `pyproject.toml` with project metadata and optional extras, and pin build-system tools `setuptools==80.9.0` and `wheel==0.45.1`. 
- Replace `requirements.txt` with locked files under `requirements/`: `build.txt`, `runtime.txt`, and `development.txt`, and update `README.md` to install via `requirements/development.txt`. 
- Convert `Dockerfile` to a multi-stage build that builds a wheel in a builder stage using `requirements/build.txt` and installs only `requirements/runtime.txt` in the final image, avoiding dev packages in the runtime. 
- Simplify `setup.py` to a minimal compatibility shim and switch CI to install the locked development dependencies (`requirements/development.txt`) and install the package with `--no-deps`. 
- Update GitHub Actions workflow (`.github/workflows/main.yml`) to cache pip using `cache-dependency-path` and to install `requirements/development.txt`, then run tests, `ruff`, and `mypy`. 
- Add `docs/reproducibility.md` and update `docs/INDEX.md` with reproducible build and lock refresh instructions. 

### Testing
- CI is configured to run `pytest -q --cov=ivt_filter --cov-report=xml --cov-fail-under=55` across Python 3.10, 3.11, and 3.12 along with `ruff` and `mypy`. (These steps are added to the GitHub Actions workflow.)
- Ran the test suite locally with `pytest` and static checks with `ruff` and `mypy`, and the checks completed successfully. 
- Docker build recipe documented and verified with the pinned digest build command `docker build --pull=false -t ivt-filter:latest .`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd0529c7c8323a2202ccaf91e4887)