### PR TITLE
Define extractor timestamp conversion behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ Here's a typical workflow for processing a file:
 If you export from Tobii Pro Lab, use the built-in extractor:
 
 ```bash
-python extractor.py raw_tobii_export.tsv data.tsv
+python extractor.py --input raw_tobii_export.tsv --output data.tsv --timestamp-unit auto
 ```
 
 This converts the Tobii export to the slim format needed by the I-VT filter. It automatically:
-- Detects timestamp units (ms/us)
+- Detects timestamp units and populates millisecond and microsecond timestamps
 - Maps Tobii column names to standard format
 - Excludes calibration samples
 - Removes rows without stimulus names

--- a/extractor.py
+++ b/extractor.py
@@ -44,40 +44,51 @@ RAW_COLUMNS = {
     "pupil_right_mm": "Pupil diameter right [mm]",
 }
 
-# Native timestamp columns - no conversion needed
-RECORDING_TIMESTAMP_MS_ALTERNATIVES = [
-    "Recording timestamp [ms]",
-]
-
-EYETRACKER_TIMESTAMP_US_ALTERNATIVES = [
-    "Eyetracker timestamp [μs]",
-    "Eyetracker timestamp [us]",
+# Timestamp headers that can be detected in Tobii exports.  Recording timestamps
+# are preferred when a manual unit override requires choosing one source column.
+TIMESTAMP_ALTERNATIVES = [
+    ("Recording timestamp [ms]", "ms"),
+    ("Recording timestamp [μs]", "us"),
+    ("Recording timestamp [us]", "us"),
+    ("Recording timestamp [ns]", "ns"),
+    ("Eyetracker timestamp [μs]", "us"),
+    ("Eyetracker timestamp [us]", "us"),
 ]
 
 
 class TimestampUnitDetector:
-    """Detects and extracts timestamp columns from Tobii exports (no conversion)."""
+    """Detect timestamp columns and convert their values between supported units."""
 
     def detect_columns(self, df: pd.DataFrame) -> tuple[Optional[str], Optional[str]]:
-        """Find recording (ms) and eyetracker (us) timestamp columns.
-        
-        Returns:
-            (recording_ms_col, eyetracker_us_col) where either can be None
-        """
-        recording_col = None
-        eyetracker_col = None
-        
-        for col_name in RECORDING_TIMESTAMP_MS_ALTERNATIVES:
-            if col_name in df.columns:
-                recording_col = col_name
-                break
-        
-        for col_name in EYETRACKER_TIMESTAMP_US_ALTERNATIVES:
-            if col_name in df.columns:
-                eyetracker_col = col_name
-                break
-        
-        return recording_col, eyetracker_col
+        """Return the first native millisecond and microsecond timestamp columns."""
+        native_ms_col = self._find_column(df, "ms")
+        native_us_col = self._find_column(df, "us")
+        return native_ms_col, native_us_col
+
+    def detect_column(self, df: pd.DataFrame) -> tuple[Optional[str], Optional[str]]:
+        """Return the preferred timestamp column and the unit declared by its header."""
+        for column_name, unit in TIMESTAMP_ALTERNATIVES:
+            if column_name in df.columns:
+                return column_name, unit
+        return None, None
+
+    def _find_column(self, df: pd.DataFrame, unit: str) -> Optional[str]:
+        """Return the first timestamp column whose header declares ``unit``."""
+        for column_name, column_unit in TIMESTAMP_ALTERNATIVES:
+            if column_unit == unit and column_name in df.columns:
+                return column_name
+        return None
+
+    def convert(self, values: pd.Series, from_unit: str, to_unit: str) -> pd.Series:
+        """Convert timestamp ``values`` from one supported unit to another."""
+        scale_in_nanoseconds = {"ms": 1_000_000, "us": 1_000, "ns": 1}
+        try:
+            scale = scale_in_nanoseconds[from_unit] / scale_in_nanoseconds[to_unit]
+        except KeyError as exc:
+            raise ValueError(
+                "timestamp unit must be one of: 'auto', 'ms', 'us', 'ns'"
+            ) from exc
+        return values * scale
 
 
 class TobiiDataExtractor:
@@ -86,7 +97,7 @@ class TobiiDataExtractor:
     Responsibilities:
         - Read Tobii TSV files with correct format settings
         - Filter eye tracker data
-        - Convert timestamps to milliseconds
+        - Detect timestamps and populate millisecond and microsecond columns
         - Map columns to standardized schema
         - Write slim TSV for IVT processing
     """
@@ -193,30 +204,59 @@ class TobiiDataExtractor:
         self,
         source: pd.DataFrame,
         target: pd.DataFrame,
-        unit_override: str,  # Not used anymore, kept for API compatibility
+        unit_override: str,
     ) -> pd.DataFrame:
-        """Extract native timestamp columns without conversion.
-        
-        - time_ms: From Recording timestamp [ms] (native milliseconds)
-        - time_us: From Eyetracker timestamp [μs] (native microseconds)
+        """Populate ``time_ms`` and ``time_us`` using detection or an explicit unit.
+
+        In ``auto`` mode, native millisecond and microsecond timestamps are
+        preserved when both exist.  When only one timestamp exists, the other
+        output column is derived from it.  For an explicit ``ms``, ``us``, or
+        ``ns`` override, the preferred detected source column is interpreted as
+        that unit and converted into both output units.
         """
-        recording_col, eyetracker_col = self.timestamp_detector.detect_columns(source)
+        if unit_override not in {"auto", "ms", "us", "ns"}:
+            raise ValueError("timestamp unit must be one of: 'auto', 'ms', 'us', 'ns'")
 
-        # Extract required time_ms from Recording timestamp [ms]. Without it,
-        # the slim export cannot be sorted or consumed by the IVT pipeline.
-        if recording_col is None:
-            raise ValueError("Recording timestamp [ms] column not found")
-        target["time_ms"] = source[recording_col].copy()
-        print("[Extractor] Using Recording timestamp [ms] for time_ms")
+        if unit_override == "auto":
+            native_ms_col, native_us_col = self.timestamp_detector.detect_columns(source)
+            if native_ms_col is not None or native_us_col is not None:
+                if native_ms_col is not None:
+                    target["time_ms"] = source[native_ms_col].copy()
+                    print(f"[Extractor] Using {native_ms_col} for time_ms")
+                else:
+                    target["time_ms"] = self.timestamp_detector.convert(
+                        source[native_us_col], "us", "ms"
+                    )
+                    print(f"[Extractor] Deriving time_ms from {native_us_col}")
 
-        # Extract time_us from Eyetracker timestamp [μs]
-        if eyetracker_col is not None:
-            target["time_us"] = source[eyetracker_col].copy()
-            print(f"[Extractor] Using Eyetracker timestamp [μs] for time_us")
+                if native_us_col is not None:
+                    target["time_us"] = source[native_us_col].copy()
+                    print(f"[Extractor] Using {native_us_col} for time_us")
+                else:
+                    target["time_us"] = self.timestamp_detector.convert(
+                        source[native_ms_col], "ms", "us"
+                    )
+                    print(f"[Extractor] Deriving time_us from {native_ms_col}")
+                return target
+
+            timestamp_col, detected_unit = self.timestamp_detector.detect_column(source)
+            if timestamp_col is None or detected_unit is None:
+                raise ValueError("No usable timestamp column found")
+            unit_to_use = detected_unit
+            print(f"[Extractor] Auto-detected {timestamp_col} as {unit_to_use}")
         else:
-            print("[Extractor] Warning: Eyetracker timestamp [μs] not found")
-            target["time_us"] = pd.NA
+            timestamp_col, _ = self.timestamp_detector.detect_column(source)
+            if timestamp_col is None:
+                raise ValueError("No usable timestamp column found")
+            unit_to_use = unit_override
+            print(f"[Extractor] Interpreting {timestamp_col} as {unit_to_use}")
 
+        target["time_ms"] = self.timestamp_detector.convert(
+            source[timestamp_col], unit_to_use, "ms"
+        )
+        target["time_us"] = self.timestamp_detector.convert(
+            source[timestamp_col], unit_to_use, "us"
+        )
         return target
 
     def _map_columns(

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,4 +1,4 @@
-"""Focused tests for Tobii archive extraction and native timestamp handling."""
+"""Focused tests for Tobii archive extraction and timestamp conversion."""
 
 from __future__ import annotations
 
@@ -6,6 +6,10 @@ import pandas as pd
 import pytest
 
 from extractor import TimestampUnitDetector, TobiiDataExtractor
+
+
+def _convert(source: pd.DataFrame, timestamp_unit: str = "auto") -> pd.DataFrame:
+    return TobiiDataExtractor()._convert_timestamps(source, pd.DataFrame(), timestamp_unit)
 
 
 def test_timestamp_detector_accepts_ascii_microsecond_header() -> None:
@@ -16,6 +20,51 @@ def test_timestamp_detector_accepts_ascii_microsecond_header() -> None:
         "Recording timestamp [ms]",
         "Eyetracker timestamp [us]",
     )
+
+
+def test_auto_derives_microseconds_from_native_milliseconds() -> None:
+    result = _convert(pd.DataFrame({"Recording timestamp [ms]": [12, 13.5]}))
+
+    assert result["time_ms"].tolist() == [12, 13.5]
+    assert result["time_us"].tolist() == [12_000, 13_500]
+
+
+def test_auto_derives_milliseconds_from_native_microseconds() -> None:
+    result = _convert(pd.DataFrame({"Eyetracker timestamp [μs]": [12_000, 13_500]}))
+
+    assert result["time_ms"].tolist() == [12, 13.5]
+    assert result["time_us"].tolist() == [12_000, 13_500]
+
+
+def test_auto_preserves_both_native_timestamp_columns() -> None:
+    result = _convert(
+        pd.DataFrame(
+            {
+                "Recording timestamp [ms]": [12, 13],
+                "Eyetracker timestamp [μs]": [12_123, 13_123],
+            }
+        )
+    )
+
+    assert result["time_ms"].tolist() == [12, 13]
+    assert result["time_us"].tolist() == [12_123, 13_123]
+
+
+@pytest.mark.parametrize(
+    ("timestamp_unit", "values", "expected_ms", "expected_us"),
+    [
+        ("ms", [1, 2], [1, 2], [1_000, 2_000]),
+        ("us", [1_000, 2_000], [1, 2], [1_000, 2_000]),
+        ("ns", [1_000_000, 2_000_000], [1, 2], [1_000, 2_000]),
+    ],
+)
+def test_explicit_timestamp_unit_override_converts_preferred_source(
+    timestamp_unit, values, expected_ms, expected_us
+) -> None:
+    result = _convert(pd.DataFrame({"Recording timestamp [ms]": values}), timestamp_unit)
+
+    assert result["time_ms"].tolist() == expected_ms
+    assert result["time_us"].tolist() == expected_us
 
 
 def test_extract_filters_rows_sorts_by_recording_time_and_preserves_native_timestamps(
@@ -43,31 +92,19 @@ def test_extract_filters_rows_sorts_by_recording_time_and_preserves_native_times
     assert result["gaze_left_x_mm"].tolist() == [1.0, 2.0]
 
 
-def test_extract_rejects_missing_recording_timestamp_column(tmp_path) -> None:
+def test_extract_rejects_missing_timestamp_columns(tmp_path) -> None:
     input_path = tmp_path / "raw.tsv"
     output_path = tmp_path / "slim.tsv"
     pd.DataFrame({"Presented Stimulus name": ["Target"]}).to_csv(
         input_path, sep="\t", index=False
     )
 
-    with pytest.raises(ValueError, match=r"Recording timestamp \[ms\] column not found"):
+    with pytest.raises(ValueError, match="No usable timestamp column found"):
         TobiiDataExtractor().extract(input_path, output_path)
 
     assert not output_path.exists()
 
 
-def test_extract_keeps_microsecond_timestamp_optional(tmp_path) -> None:
-    input_path = tmp_path / "raw.tsv"
-    output_path = tmp_path / "slim.tsv"
-    pd.DataFrame(
-        {
-            "Presented Stimulus name": ["Target"],
-            "Recording timestamp [ms]": [12],
-        }
-    ).to_csv(input_path, sep="\t", index=False)
-
-    TobiiDataExtractor().extract(input_path, output_path)
-
-    result = pd.read_csv(output_path, sep="\t", decimal=",")
-    assert result["time_ms"].tolist() == [12]
-    assert result["time_us"].isna().all()
+def test_explicit_override_rejects_missing_timestamp_columns() -> None:
+    with pytest.raises(ValueError, match="No usable timestamp column found"):
+        _convert(pd.DataFrame({"Presented Stimulus name": ["Target"]}), "us")


### PR DESCRIPTION
### Motivation
- Ensure consistent, well-defined handling of Tobii timestamp headers and units so downstream IVT processing always receives usable time axes. 
- Support explicit overrides (`ms`, `us`, `ns`) and an `auto` mode that preserves native precision and derives the missing representation when possible. 
- Reject inputs that contain no usable timestamp column instead of producing an all-missing time axis.

### Description
- Implemented timestamp detection and conversion utilities in `TimestampUnitDetector` including `detect_columns`, `detect_column`, `_find_column`, and `convert` to map headers to units and scale values between `ms`, `us`, and `ns`.
- Implemented `TobiiDataExtractor._convert_timestamps` to support `timestamp_unit` values `auto`, `ms`, `us`, and `ns`, populate both `time_ms` and `time_us`, derive missing representations when only one native column exists, and raise `ValueError` when no usable timestamp is found.
- Updated README extraction example to use `python extractor.py --input raw_tobii_export.tsv --output data.tsv --timestamp-unit auto` and clarified the extractor behavior text.
- Added focused unit tests in `tests/test_extractor.py` covering native ms/us headers, both columns present, explicit overrides (`ms`, `us`, `ns`), and missing-timestamp failure cases.

### Testing
- Ran the new focused extractor tests with `pytest tests/test_extractor.py` and they passed.
- Ran a targeted test subset with `pytest tests/test_extractor.py tests/test_velocity_processing_components.py` and all ran green.
- Ran the full test suite with `pytest` and observed all tests passing (`311 passed, 2 skipped`).
- Performed static/compile checks via `python -m compileall` and `mypy` with no reported issues.