### PR TITLE
Harden release workflows: require CI checks for tag publishes and pin dev tools

### DIFF
--- a/.github/workflows/ContainerRegestry.yml
+++ b/.github/workflows/ContainerRegestry.yml
@@ -2,9 +2,6 @@ name: Publish Docker Image
 
 on:
   push:
-    branches:
-      - main
-      - testTDD
     tags:
       - 'v*.*.*'
 
@@ -13,6 +10,7 @@ jobs:
     uses: ./.github/workflows/main.yml
 
   build-and-push:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: checks
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,11 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  # Tagged commits are verified by the publishing workflows through workflow_call.
+  # Keeping tags out of this trigger avoids an unguarded duplicate CI run on releases.
   push:
+    branches:
+      - '**'
   pull_request:
   workflow_call:
 
@@ -25,10 +29,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+          cache-dependency-path: constraints-dev.txt
 
-      - name: Install package and pinned test tools
+      - name: Install package and pinned development tools
         run: |
-          python -m pip install --constraint constraints-dev.txt pytest pytest-cov
+          python -m pip install --requirement constraints-dev.txt
           python -m pip install --editable .
 
       - name: Run tests with coverage
@@ -50,8 +55,9 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-      - name: Install pinned lint tool
-        run: python -m pip install --constraint constraints-dev.txt ruff
+          cache-dependency-path: constraints-dev.txt
+      - name: Install pinned development tools
+        run: python -m pip install --requirement constraints-dev.txt
       - name: Lint package
         run: ruff check ivt_filter
 
@@ -65,9 +71,10 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-      - name: Install package and pinned type-check tool
+          cache-dependency-path: constraints-dev.txt
+      - name: Install package and pinned development tools
         run: |
-          python -m pip install --constraint constraints-dev.txt mypy
+          python -m pip install --requirement constraints-dev.txt
           python -m pip install --editable .
       - name: Type check package
         run: mypy ivt_filter
@@ -82,8 +89,9 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
-      - name: Install pinned build tool
-        run: python -m pip install --constraint constraints-dev.txt build
+          cache-dependency-path: constraints-dev.txt
+      - name: Install pinned development tools
+        run: python -m pip install --requirement constraints-dev.txt
       - name: Build distributions
         run: python -m build
       - name: Install wheel into isolated environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     uses: ./.github/workflows/main.yml
 
   publish:
+    if: startsWith(github.ref, 'refs/tags/v')
     needs: checks
     runs-on: ubuntu-latest
     steps:

--- a/constraints-dev.txt
+++ b/constraints-dev.txt
@@ -1,5 +1,5 @@
 # Exact versions for CI and local development tooling.
-# Install the tool you need with: python -m pip install --constraint constraints-dev.txt <tool>
+# Install the pinned CI/development toolset with: python -m pip install --requirement constraints-dev.txt
 build==1.3.0
 mypy==1.20.2
 pytest==9.0.3

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -22,4 +22,4 @@ Require every blocking job exposed by **Python CI**:
 - `package-build`
 - `container-smoke`
 
-The `package-build` job installs the generated wheel into an isolated virtual environment and runs the CLI from that installed artifact. The `container-smoke` job builds the image and verifies both its CLI and package import. Tagged PyPI releases and GHCR publication call the reusable Python CI workflow and cannot publish unless all of these checks succeed for the tagged commit.
+The `package-build` job installs the generated wheel into an isolated virtual environment and runs the CLI from that installed artifact. The `container-smoke` job builds the image and verifies both its CLI and package import. Tagged PyPI releases and GHCR publication call the reusable Python CI workflow and cannot publish unless all of these checks succeed for the tagged commit. GHCR publication is intentionally tag-only: ordinary pushes to `main` do not publish release images.


### PR DESCRIPTION
### Motivation
- Ensure that publishing to PyPI and GHCR only happens for a tag after the full CI matrix (tests, lint, type-check, package-build, container-smoke) has succeeded for the exact tagged commit.
- Avoid installing floating tool versions inside workflows and instead pin development/CI tools through the project constraints file.
- Validate installed wheel and CLI behavior from the built artifact before publishing.
- Make branch-protection expectations explicit so `main` cannot be updated without required checks and reviews.

### Description
- Updated `.github/workflows/main.yml` to centralize dev-tool installation via `constraints-dev.txt`, add `cache-dependency-path: constraints-dev.txt`, and keep the coverage gate at `--cov-fail-under=58` while leaving the reusable CI workflow in place for tag verification.
- Modified `.github/workflows/ContainerRegestry.yml` and `.github/workflows/release.yml` so publication triggers remain `v*.*.*` tags and added explicit `if: startsWith(github.ref, 'refs/tags/v')` guards on the publish jobs so images/releases only push after the reusable checks finish.
- Preserved the `package-build` wheel smoke test that installs the built wheel into an isolated venv and verifies `import ivt_filter` and the CLI via `/tmp/ivt-wheel-smoke/bin/python -m ivt_filter.cli --help`.
- Updated `constraints-dev.txt` messaging to recommend `python -m pip install --requirement constraints-dev.txt` and clarified branch-protection guidance in `docs/branch-protection.md` (required CI checks, at least one approving review, prevent direct pushes, block force-pushes/deletion, require up-to-date branches; GHCR publication is tag-only).

### Testing
- Ran the full test suite with `python -m pytest -q` which completed as `305 passed, 2 skipped`.
- Ran lint and static checks with `ruff check ivt_filter` and `mypy ivt_filter`, both of which succeeded (`ruff` reported all checks passed and `mypy` returned no issues).
- Verified Python compilation with `python -m compileall -q ivt_filter extractor.py` and parsed the edited workflow YAMLs successfully with a YAML loader script.
- Executed a workflow-policy assertion script that validated branch-only ordinary CI triggers, tag-only publisher triggers, `if` guards on publish jobs, `--cov-fail-under=58`, and `constraints-dev.txt` usage; all assertions passed.
- Environment-limited checks: `python -m pip install --requirement constraints-dev.txt` could not complete in this sandbox due to an external package proxy returning `403 Forbidden`, and `docker` is not available here so the `container-smoke` steps remain CI-only and were not executed locally.
