### PR TITLE
Make classifier reconstruction heuristics explicit and opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,28 @@ Output: classified eye-tracking events
 
 **Post-Processing**: Merge saccades separated by brief periods (e.g., <75 ms) and discard very short fixations (<60 ms) that are likely noise.
 
+### Strict I-VT Baseline and Optional Reconstruction Heuristics
+
+The default classifier is a strict I-VT baseline. After validity handling, each finite velocity is classified with one inclusive threshold comparison:
+
+- `velocity < threshold` → `Fixation`
+- `velocity >= threshold` → `Saccade`
+- invalid eye samples → `EyesNotFound`
+- missing or non-finite velocity → `Unclassified`
+
+Reconstruction heuristics are opt-in and are not part of the baseline algorithm:
+
+| Option | Behavior when enabled |
+|--------|-----------------------|
+| `--enable-invalid-window-neighbor-confirmation` | Requires an adjacent above-threshold velocity before an invalid-window sample can become a saccade. |
+| `--enable-hysteresis` | Retains the previous motion label while velocity remains in the band immediately below the saccade threshold. |
+| `--hysteresis-width <deg/s>` | Sets the width of that optional hysteresis band (default: `2.0`). |
+| `--enable-near-threshold-hybrid` | Allows alternative-velocity refinement near the threshold. |
+| `--enable-eye-jump-rule` | Allows alternative-velocity correction for eye-position jumps. |
+| `--confident-switch-enabled` | Allows confident alternative-velocity switching away from the threshold. |
+
+Classifier output contains diagnostic columns including `classifier_refinement_rules_enabled`, `classifier_invalid_window_neighbor_confirmation_enabled`, `classifier_hysteresis_enabled`, and `classifier_hysteresis_width_deg_per_sec`, so exported runs state which optional rules were active.
+
 ---
 
 ## Installation & Setup

--- a/docs/TECHNICAL_SPECIFICATION.md
+++ b/docs/TECHNICAL_SPECIFICATION.md
@@ -228,6 +228,35 @@ Expected Output:
 Explanation: Moderate difference for large movements
 ```
 
+## I-VT Classification Semantics
+
+### Strict Baseline
+
+The default classifier implements the velocity-threshold step independently of the velocity-calculation method. Valid samples with finite velocity use a single inclusive threshold boundary:
+
+```python
+if velocity >= velocity_threshold_deg_per_sec:
+    return "Saccade"
+return "Fixation"
+```
+
+Validity handling precedes the threshold comparison. Invalid eye samples are labeled `EyesNotFound`; missing or non-finite velocities are labeled `Unclassified`. No invalid-window threshold adjustment, neighbor confirmation, or hysteresis is applied in baseline mode.
+
+### Optional Reconstruction Heuristics
+
+The classifier exposes reconstruction rules separately from the strict baseline:
+
+| Configuration field | Default | Effect when enabled |
+|---------------------|---------|---------------------|
+| `enable_invalid_window_neighbor_confirmation` | `False` | An invalid-window sample at or above the threshold becomes a saccade only when an adjacent velocity is also at or above the threshold. |
+| `enable_hysteresis` | `False` | A finite velocity in the band immediately below the saccade threshold retains the previous fixation/saccade label when one exists. |
+| `hysteresis_width_deg_per_sec` | `2.0` | Configures the optional hysteresis band width in degrees per second. |
+| `enable_near_threshold_hybrid` | `False` | Permits alternative-velocity refinement near the threshold. |
+| `enable_eye_jump_rule` | `False` | Permits alternative-velocity correction after eye-position jumps. |
+| `enable_confident_switch` | `False` | Permits confident switching to an alternative velocity method. |
+
+Each classified output frame records active heuristics in `classifier_refinement_rules_enabled`. Dedicated columns also record whether invalid-window neighbor confirmation and hysteresis were enabled and the configured hysteresis width. This keeps exported results self-describing when experiments compare the strict baseline with reconstruction variants.
+
 ## Implementation Notes
 
 ### Performance Optimization

--- a/ivt_filter/cli.py
+++ b/ivt_filter/cli.py
@@ -303,6 +303,30 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Velocity-Threshold in deg/s fuer I-VT (default: 30).",
     )
     
+    # Optional classifier reconstruction heuristics
+    parser.add_argument(
+        "--enable-invalid-window-neighbor-confirmation",
+        action="store_true",
+        help=(
+            "Require an adjacent above-threshold velocity before classifying an "
+            "invalid-window sample as a saccade. Disabled for strict I-VT baseline runs."
+        ),
+    )
+    parser.add_argument(
+        "--enable-hysteresis",
+        action="store_true",
+        help=(
+            "Retain the previous motion label in a band immediately below the threshold. "
+            "Disabled for strict I-VT baseline runs."
+        ),
+    )
+    parser.add_argument(
+        "--hysteresis-width",
+        type=float,
+        default=2.0,
+        help="Width of the optional hysteresis band in deg/s (default: 2.0).",
+    )
+
     # Near-threshold hybrid strategy
     parser.add_argument(
         "--enable-near-threshold-hybrid",

--- a/ivt_filter/config/config.py
+++ b/ivt_filter/config/config.py
@@ -286,6 +286,16 @@ class IVTClassifierConfig:
     """
 
     velocity_threshold_deg_per_sec: float = 30.0
+
+    # Optional reconstruction heuristics. Disabled by default so the classifier
+    # behaves as a strict I-VT velocity-threshold classifier.
+    # Require an adjacent above-threshold velocity before classifying an
+    # invalid-window sample as a saccade.
+    enable_invalid_window_neighbor_confirmation: bool = False
+    # Retain the previous motion label while velocity is in the band immediately
+    # below the saccade threshold.
+    enable_hysteresis: bool = False
+    hysteresis_width_deg_per_sec: float = 2.0
     
     # Stage 1: Near-threshold hybrid strategy
     # Enable hybrid classification near threshold using alternative velocity

--- a/ivt_filter/config/config_builder.py
+++ b/ivt_filter/config/config_builder.py
@@ -65,6 +65,9 @@ class ConfigBuilder:
         """Build classifier configuration from CLI arguments."""
         return IVTClassifierConfig(
             velocity_threshold_deg_per_sec=args.threshold,
+            enable_invalid_window_neighbor_confirmation=args.enable_invalid_window_neighbor_confirmation,
+            enable_hysteresis=args.enable_hysteresis,
+            hysteresis_width_deg_per_sec=args.hysteresis_width,
             enable_near_threshold_hybrid=args.enable_near_threshold_hybrid,
             near_threshold_band=args.near_threshold_band,
             near_threshold_band_lower=args.near_threshold_band_lower,

--- a/ivt_filter/processing/classification.py
+++ b/ivt_filter/processing/classification.py
@@ -108,22 +108,33 @@ class IVTClassifier:
         df = df.copy()
         self._df_context = df  # Store for alternative velocity access
 
-        # Pre-compute neighbor support for high velocities in invalid windows
-        # (prevents single-sample spikes from invalid-eye windows turning into saccades)
+        # Record enabled classifier refinements in each result frame so exported
+        # runs remain self-describing even without experiment metadata.
+        enabled_refinements = self._enabled_refinement_rules()
+        df["classifier_refinement_rules_enabled"] = ",".join(enabled_refinements)
+        df["classifier_invalid_window_neighbor_confirmation_enabled"] = (
+            self.cfg.enable_invalid_window_neighbor_confirmation
+        )
+        df["classifier_hysteresis_enabled"] = self.cfg.enable_hysteresis
+        df["classifier_hysteresis_width_deg_per_sec"] = self.cfg.hysteresis_width_deg_per_sec
+
+        # Neighbor support is diagnostic whenever the rule is enabled. Baseline
+        # mode deliberately avoids applying invalid-window reconstruction logic.
         df["window_any_invalid"] = df.get("window_any_invalid", False)
         df["velocity_neighbor_support"] = False
-        velocities = df["velocity_deg_per_sec"].to_numpy()
-        invalid_flags = df["window_any_invalid"].fillna(False).to_numpy().astype(bool)
-        threshold = float(self.cfg.velocity_threshold_deg_per_sec)
-        support = np.zeros(len(df), dtype=bool)
-        for i in range(len(df)):
-            v = velocities[i]
-            if not invalid_flags[i] or not np.isfinite(v) or v < threshold:
-                continue
-            prev_ok = i > 0 and np.isfinite(velocities[i - 1]) and velocities[i - 1] >= threshold
-            next_ok = i + 1 < len(df) and np.isfinite(velocities[i + 1]) and velocities[i + 1] >= threshold
-            support[i] = prev_ok or next_ok
-        df["velocity_neighbor_support"] = support
+        if self.cfg.enable_invalid_window_neighbor_confirmation:
+            velocities = df["velocity_deg_per_sec"].to_numpy()
+            invalid_flags = df["window_any_invalid"].fillna(False).to_numpy().astype(bool)
+            threshold = float(self.cfg.velocity_threshold_deg_per_sec)
+            support = np.zeros(len(df), dtype=bool)
+            for i in range(len(df)):
+                v = velocities[i]
+                if not invalid_flags[i] or not np.isfinite(v) or v < threshold:
+                    continue
+                prev_ok = i > 0 and np.isfinite(velocities[i - 1]) and velocities[i - 1] >= threshold
+                next_ok = i + 1 < len(df) and np.isfinite(velocities[i + 1]) and velocities[i + 1] >= threshold
+                support[i] = prev_ok or next_ok
+            df["velocity_neighbor_support"] = support
         
         # Add diagnostic columns for refinement
         if self.cfg.enable_near_threshold_hybrid or self.cfg.enable_eye_jump_rule:
@@ -133,7 +144,14 @@ class IVTClassifier:
             # Pre-compute alternative velocities where needed
             df = self._precompute_refinements(df)
         
-        df["ivt_sample_type"] = df.apply(self._classify_sample, axis=1)
+        labels = []
+        previous_motion_label: Optional[str] = None
+        for _, row in df.iterrows():
+            label = self._classify_sample(row, previous_motion_label)
+            labels.append(label)
+            if label in ("Fixation", "Saccade"):
+                previous_motion_label = label
+        df["ivt_sample_type"] = labels
 
         df = rebuild_events_from_sample_labels(
             df,
@@ -355,8 +373,25 @@ class IVTClassifier:
         df["refinement_applied"] = refinement_reasons
         return df
 
-    def _classify_sample(self, row: pd.Series) -> str:
-        """Classify a single sample with optional refinement."""
+    def _enabled_refinement_rules(self) -> list[str]:
+        """Return enabled non-baseline classifier rules for run diagnostics."""
+        rules = []
+        if self.cfg.enable_invalid_window_neighbor_confirmation:
+            rules.append("invalid_window_neighbor_confirmation")
+        if self.cfg.enable_hysteresis:
+            rules.append("hysteresis")
+        if self.cfg.enable_near_threshold_hybrid:
+            rules.append("near_threshold_hybrid")
+        if self.cfg.enable_eye_jump_rule:
+            rules.append("eye_jump")
+        if self.cfg.enable_confident_switch:
+            rules.append("confident_switch")
+        return rules
+
+    def _classify_sample(
+        self, row: pd.Series, previous_motion_label: Optional[str] = None
+    ) -> str:
+        """Classify a single sample with explicitly enabled optional refinements."""
         if not self.sample_validator.is_valid(row):
             return "EyesNotFound"
         
@@ -367,54 +402,48 @@ class IVTClassifier:
         if velocity_base is None:
             return "Unclassified"
         
-        # Use refined velocity if available
+        # Use refined velocity if available.
         velocity_final = velocity_base
         if "velocity_refined" in row and pd.notna(row["velocity_refined"]):
             velocity_final = float(row["velocity_refined"])
         
-        # Dynamic threshold: lower for invalid windows only in low-velocity band (<35)
         threshold = self.cfg.velocity_threshold_deg_per_sec
         invalid_window = bool(row.get("window_any_invalid", False))
-        neighbor_support = bool(row.get("velocity_neighbor_support", True))
+        neighbor_support = bool(row.get("velocity_neighbor_support", False))
 
-        # Confident mismatch switch: if base is far from threshold and alternative disagrees, adopt alternative
-        if getattr(self.cfg, "enable_confident_switch", False):
-            alt_v = row.get("velocity_alt_deg_per_sec", None)
-            alt_v = self.velocity_validator.parse_velocity(alt_v)
+        # Confident mismatch switch: if base is far from threshold and alternative
+        # disagrees, adopt the alternative. Invalid-window confirmation remains an
+        # independent option and is never implied by this rule.
+        if self.cfg.enable_confident_switch:
+            alt_v = self.velocity_validator.parse_velocity(
+                row.get("velocity_alt_deg_per_sec", None)
+            )
             if alt_v is not None and math.isfinite(alt_v):
                 base_side = velocity_final >= threshold
                 alt_side = alt_v >= threshold
-                if invalid_window and alt_side and not neighbor_support:
-                    alt_side = False
                 dist_base = abs(velocity_final - threshold)
                 dist_alt = abs(alt_v - threshold)
-                margin = getattr(self.cfg, "confident_switch_margin_deg", 4.0)
+                margin = self.cfg.confident_switch_margin_deg
                 if invalid_window:
-                    # In invalid windows, switch on disagreement; require neighbor support for alt saccades
-                    if alt_side != base_side and not (alt_side and not neighbor_support):
+                    if alt_side != base_side:
                         velocity_final = alt_v
-                else:
-                    # Default confident switch: alt must disagree, be confident, and farther from threshold than base
-                    if dist_alt >= margin and alt_side != base_side and dist_alt > dist_base:
-                        velocity_final = alt_v
-        if invalid_window:
-            if velocity_final < 35.0:
-                threshold = min(threshold, 27.0)
+                elif dist_alt >= margin and alt_side != base_side and dist_alt > dist_base:
+                    velocity_final = alt_v
 
-        # Hysteresis: require stronger drop to switch to Fixation
-        hysteresis_delta = 2.0
-        saccade_cut = threshold
-        fixation_cut = max(0.0, threshold - hysteresis_delta)
+        if velocity_final >= threshold:
+            if (
+                self.cfg.enable_invalid_window_neighbor_confirmation
+                and invalid_window
+                and not neighbor_support
+            ):
+                return "Fixation"
+            return "Saccade"
 
-        if velocity_final >= saccade_cut:
-            if invalid_window and not neighbor_support:
-                # Require neighbor confirmation when window contains invalid eyes
-                pass
-            else:
-                return "Saccade"
-        if velocity_final < fixation_cut:
-            return "Fixation"
-        # In-between band: default to Fixation to avoid propagating stale labels
+        if self.cfg.enable_hysteresis:
+            fixation_cut = max(0.0, threshold - self.cfg.hysteresis_width_deg_per_sec)
+            if velocity_final >= fixation_cut and previous_motion_label is not None:
+                return previous_motion_label
+
         return "Fixation"
 
 

--- a/tests/test_ci_coverage_regressions.py
+++ b/tests/test_ci_coverage_regressions.py
@@ -33,7 +33,10 @@ def test_normalize_timestamps_rejects_missing_configured_column() -> None:
 
 
 def test_classifier_threshold_is_inclusive_and_invalid_window_spike_needs_support() -> None:
-    cfg = IVTClassifierConfig(velocity_threshold_deg_per_sec=30.0)
+    cfg = IVTClassifierConfig(
+        velocity_threshold_deg_per_sec=30.0,
+        enable_invalid_window_neighbor_confirmation=True,
+    )
     source = pd.DataFrame(
         {
             "velocity_deg_per_sec": [29.999, 30.0, 100.0, 30.0],
@@ -54,7 +57,8 @@ def test_classifier_invalid_window_rejects_isolated_velocity_spike() -> None:
                 "velocity_deg_per_sec": [1.0, 100.0, 1.0],
                 "window_any_invalid": [False, True, False],
             }
-        )
+        ),
+        IVTClassifierConfig(enable_invalid_window_neighbor_confirmation=True),
     )
 
     assert result["ivt_sample_type"].tolist() == ["Fixation", "Fixation", "Fixation"]

--- a/tests/test_classification_regressions.py
+++ b/tests/test_classification_regressions.py
@@ -48,6 +48,62 @@ def test_apply_ivt_classifier_uses_default_config_and_classifies_velocities() ->
     ]
 
 
+def test_strict_baseline_threshold_boundary_ignores_invalid_window_heuristics() -> None:
+    result = apply_ivt_classifier(
+        pd.DataFrame(
+            {
+                "velocity_deg_per_sec": [29.999, 30.0, 30.001],
+                "window_any_invalid": [True, True, True],
+            }
+        ),
+        IVTClassifierConfig(velocity_threshold_deg_per_sec=30.0),
+    )
+
+    assert result["ivt_sample_type"].tolist() == ["Fixation", "Saccade", "Saccade"]
+    assert result["classifier_refinement_rules_enabled"].tolist() == ["", "", ""]
+    assert not result["classifier_invalid_window_neighbor_confirmation_enabled"].any()
+    assert not result["classifier_hysteresis_enabled"].any()
+
+
+def test_enabled_neighbor_confirmation_and_hysteresis_refine_threshold_boundary() -> None:
+    result = apply_ivt_classifier(
+        pd.DataFrame(
+            {
+                "velocity_deg_per_sec": [30.001, 29.999, 30.0, 30.001],
+                "window_any_invalid": [True, True, True, True],
+            }
+        ),
+        IVTClassifierConfig(
+            velocity_threshold_deg_per_sec=30.0,
+            enable_invalid_window_neighbor_confirmation=True,
+            enable_hysteresis=True,
+            hysteresis_width_deg_per_sec=0.01,
+        ),
+    )
+
+    assert result["ivt_sample_type"].tolist() == ["Fixation", "Fixation", "Saccade", "Saccade"]
+    assert result["velocity_neighbor_support"].tolist() == [False, False, True, True]
+    assert result["classifier_refinement_rules_enabled"].unique().tolist() == [
+        "invalid_window_neighbor_confirmation,hysteresis"
+    ]
+    assert result["classifier_invalid_window_neighbor_confirmation_enabled"].all()
+    assert result["classifier_hysteresis_enabled"].all()
+    assert result["classifier_hysteresis_width_deg_per_sec"].unique().tolist() == [0.01]
+
+
+def test_enabled_hysteresis_retains_previous_saccade_immediately_below_threshold() -> None:
+    result = apply_ivt_classifier(
+        pd.DataFrame({"velocity_deg_per_sec": [30.001, 29.999, 30.0]}),
+        IVTClassifierConfig(
+            velocity_threshold_deg_per_sec=30.0,
+            enable_hysteresis=True,
+            hysteresis_width_deg_per_sec=0.01,
+        ),
+    )
+
+    assert result["ivt_sample_type"].tolist() == ["Saccade", "Saccade", "Saccade"]
+
+
 @pytest.mark.parametrize("strategy", [Ray3DGazeDir(), TobiiGazeDirAngle()])
 @pytest.mark.parametrize(
     ("dir1", "dir2"),


### PR DESCRIPTION
### Motivation

- Remove undocumented implicit reconstruction behavior from the baseline I‑VT classifier and make any refinements explicit and configurable.
- Ensure output frames and experiment metadata record which optional refinement rules were active so runs remain self-describing.

### Description

- Added explicit `IVTClassifierConfig` fields `enable_invalid_window_neighbor_confirmation`, `enable_hysteresis`, and `hysteresis_width_deg_per_sec`, and exposed them via CLI flags `--enable-invalid-window-neighbor-confirmation`, `--enable-hysteresis`, and `--hysteresis-width`; the CLI builder forwards these into the config.
- Refactored `IVTClassifier` so the strict baseline behavior is a simple validity check followed by an inclusive threshold comparison (`velocity >= threshold => Saccade, else Fixation`), and applied neighbor-confirmation and hysteresis only when their config flags are enabled.
- Added diagnostic output columns written into result frames: `classifier_refinement_rules_enabled`, `classifier_invalid_window_neighbor_confirmation_enabled`, `classifier_hysteresis_enabled`, and `classifier_hysteresis_width_deg_per_sec`, and preserved prior refinement/alt-velocity diagnostics (`velocity_refined`, `refinement_applied`) when applicable.
- Updated `README.md` and `docs/TECHNICAL_SPECIFICATION.md` to document the strict I‑VT baseline semantics versus optional reconstruction heuristics, and added regression tests that exercise velocities immediately below, equal to, and immediately above the threshold with refinements disabled and enabled.

### Testing

- Ran focused regression checks: `pytest tests/test_classification_regressions.py tests/test_ci_coverage_regressions.py tests/test_pipeline_config.py -q` and these completed successfully. 
- Ran the full test suite with `pytest -q`, which completed successfully with `312 passed, 2 skipped`.
- Verified CLI help includes the new flags via `python -m ivt_filter.cli --help` and confirmed no `git diff --check` issues remained.
