### PR TITLE
Add explicit velocity window policy configuration

### DIFF
--- a/ivt_filter/config/__init__.py
+++ b/ivt_filter/config/__init__.py
@@ -8,6 +8,16 @@ from .config import (
     PipelineConfig,
 )
 from .constants import PhysicalConstants
+from .window_policy import (
+    AsymmetricNeighborWindowPolicy,
+    FixedSampleWindowPolicy,
+    SampleSymmetricWindowPolicy,
+    ShiftedValidWindowPolicy,
+    TimeSymmetricWindowPolicy,
+    TobiiWindowPolicy,
+    WindowPolicy,
+    translate_legacy_window_flags,
+)
 from .config_builder import ConfigBuilder
 
 __all__ = [
@@ -18,4 +28,12 @@ __all__ = [
     "PipelineConfig",
     "PhysicalConstants",
     "ConfigBuilder",
+    "AsymmetricNeighborWindowPolicy",
+    "FixedSampleWindowPolicy",
+    "SampleSymmetricWindowPolicy",
+    "ShiftedValidWindowPolicy",
+    "TimeSymmetricWindowPolicy",
+    "TobiiWindowPolicy",
+    "WindowPolicy",
+    "translate_legacy_window_flags",
 ]

--- a/ivt_filter/config/config.py
+++ b/ivt_filter/config/config.py
@@ -34,7 +34,13 @@ Beispiel:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal, Optional, Sequence
+from typing import Literal, Optional
+
+from .window_policy import (
+    WindowPolicy,
+    translate_legacy_window_flags,
+    window_policy_from_dict,
+)
 
 
 @dataclass
@@ -82,6 +88,10 @@ class OlsenVelocityConfig:
     # expansion_radius: Search samples beyond standard window (default: 0)
     smoothing_min_samples: int = 1
     smoothing_expansion_radius: int = 0
+
+    # Normalized, tagged selector policy. Legacy flags below remain temporarily
+    # supported for direct callers and are normalized during initialization.
+    window_policy: Optional[WindowPolicy] = None
 
     # Sample-symmetrisches Fenster innerhalb des Zeitfensters
     # (gleich viele Samples links/rechts, aber immer noch durch window_length_ms begrenzt)
@@ -206,77 +216,26 @@ class OlsenVelocityConfig:
     tobii_eye_offset_interpolation: bool = False
 
     def __post_init__(self) -> None:
-        """Reject window-selector settings hidden by the legacy precedence rules."""
-        # Keep this boundary validation aligned with
-        # processing.velocity.make_window_selector(). A later compatibility-
-        # preserving migration can translate these legacy booleans into one
-        # explicit window-policy type here without changing selector behavior.
-        fixed_window_modes = self._active_fixed_window_modes()
-        non_tobii_selector_modes = self._active_non_tobii_window_modes(
-            fixed_window_modes
+        """Normalize deprecated selector flags into one tagged window policy."""
+        legacy_policy = translate_legacy_window_flags(
+            sample_symmetric_window=self.sample_symmetric_window,
+            fixed_window_samples=self.fixed_window_samples,
+            auto_fixed_window_from_ms=self.auto_fixed_window_from_ms,
+            symmetric_round_window=self.symmetric_round_window,
+            asymmetric_neighbor_window=self.asymmetric_neighbor_window,
+            shifted_valid_window=self.shifted_valid_window,
+            shifted_valid_fallback=self.shifted_valid_fallback,
+            tobii_window_mode=self.tobii_window_mode,
+            tobii_sample_interval_ms=self.tobii_sample_interval_ms,
         )
-
-        if self.tobii_window_mode and non_tobii_selector_modes:
-            self._raise_window_selector_conflict(
-                "tobii_window_mode", non_tobii_selector_modes
+        if isinstance(self.window_policy, dict):
+            self.window_policy = window_policy_from_dict(self.window_policy)
+        if self.window_policy is None:
+            self.window_policy = legacy_policy
+        elif legacy_policy.kind != "time_symmetric" and self.window_policy != legacy_policy:
+            raise ValueError(
+                "window_policy cannot be combined with contradictory deprecated legacy window flags."
             )
-
-        asymmetric_conflicts: list[str] = []
-        if self.shifted_valid_window:
-            asymmetric_conflicts.append("shifted_valid_window")
-        asymmetric_conflicts.extend(fixed_window_modes)
-        if self.sample_symmetric_window:
-            asymmetric_conflicts.append("sample_symmetric_window")
-        if self.asymmetric_neighbor_window and asymmetric_conflicts:
-            self._raise_window_selector_conflict(
-                "asymmetric_neighbor_window", asymmetric_conflicts
-            )
-
-        if self.shifted_valid_window and self.sample_symmetric_window:
-            self._raise_window_selector_conflict(
-                "shifted_valid_window", ["sample_symmetric_window"]
-            )
-
-        if fixed_window_modes and self.sample_symmetric_window:
-            self._raise_window_selector_conflict(
-                fixed_window_modes[0], ["sample_symmetric_window"]
-            )
-
-    def _active_fixed_window_modes(self) -> list[str]:
-        """Return legacy settings that activate or derive a fixed sample window."""
-        modes: list[str] = []
-        if self.fixed_window_samples is not None:
-            modes.append("fixed_window_samples")
-        if self.auto_fixed_window_from_ms:
-            modes.append("auto_fixed_window_from_ms")
-        if self.symmetric_round_window:
-            modes.append("symmetric_round_window")
-        return modes
-
-    def _active_non_tobii_window_modes(
-        self, fixed_window_modes: Sequence[str]
-    ) -> list[str]:
-        """Return selector settings hidden when Tobii window mode is active."""
-        modes: list[str] = []
-        if self.asymmetric_neighbor_window:
-            modes.append("asymmetric_neighbor_window")
-        if self.shifted_valid_window:
-            modes.append("shifted_valid_window")
-        modes.extend(fixed_window_modes)
-        if self.sample_symmetric_window:
-            modes.append("sample_symmetric_window")
-        return modes
-
-    @staticmethod
-    def _raise_window_selector_conflict(
-        selected_mode: str, ignored_modes: Sequence[str]
-    ) -> None:
-        ignored = ", ".join(ignored_modes)
-        raise ValueError(
-            "Window selector configuration is ambiguous: "
-            f"{selected_mode} takes precedence over {ignored}; "
-            "configure only one active selector mode."
-        )
 
 
 @dataclass

--- a/ivt_filter/config/config_builder.py
+++ b/ivt_filter/config/config_builder.py
@@ -14,6 +14,7 @@ from .config import (
     FixationPostConfig,
     PipelineConfig,
 )
+from .window_policy import translate_legacy_window_flags
 
 
 class ConfigBuilder:
@@ -28,7 +29,17 @@ class ConfigBuilder:
     @staticmethod
     def build_velocity_config(args: argparse.Namespace) -> OlsenVelocityConfig:
         """Build velocity configuration from CLI arguments."""
+        window_policy = translate_legacy_window_flags(
+            sample_symmetric_window=args.sample_symmetric_window,
+            fixed_window_samples=args.fixed_window_samples,
+            auto_fixed_window_from_ms=args.auto_fixed_window_from_ms,
+            symmetric_round_window=args.symmetric_round_window,
+            asymmetric_neighbor_window=args.asymmetric_neighbor_window,
+            shifted_valid_window=args.shifted_valid_window,
+            shifted_valid_fallback=args.shifted_valid_fallback,
+        )
         return OlsenVelocityConfig(
+            window_policy=window_policy,
             window_length_ms=args.window,
             time_column=args.time_column,
             time_unit=args.time_unit,
@@ -37,15 +48,8 @@ class ConfigBuilder:
             smoothing_window_samples=args.smooth_window_samples,
             smoothing_min_samples=args.smoothing_min_samples,
             smoothing_expansion_radius=args.smoothing_expansion_radius,
-            sample_symmetric_window=args.sample_symmetric_window,
-            fixed_window_samples=args.fixed_window_samples,
-            auto_fixed_window_from_ms=args.auto_fixed_window_from_ms,
             fixed_window_edge_fallback=args.fixed_window_edge_fallback,
-            symmetric_round_window=args.symmetric_round_window,
             allow_asymmetric_window=args.allow_asymmetric_window,
-            asymmetric_neighbor_window=args.asymmetric_neighbor_window,
-            shifted_valid_window=args.shifted_valid_window,
-            shifted_valid_fallback=args.shifted_valid_fallback,
             use_fixed_dt=args.use_fixed_dt,
             sampling_rate_method=args.sampling_rate_method,
             dt_calculation_method=args.dt_calculation_method,

--- a/ivt_filter/config/window_policy.py
+++ b/ivt_filter/config/window_policy.py
@@ -1,0 +1,149 @@
+"""Explicit velocity-window selection policies and legacy flag translation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Optional, Union
+
+
+@dataclass(frozen=True)
+class TimeSymmetricWindowPolicy:
+    """Select endpoints symmetrically inside the configured time span."""
+
+    kind: Literal["time_symmetric"] = "time_symmetric"
+
+
+@dataclass(frozen=True)
+class SampleSymmetricWindowPolicy:
+    """Select an equal number of samples on either side within the time span."""
+
+    kind: Literal["sample_symmetric"] = "sample_symmetric"
+
+
+@dataclass(frozen=True)
+class FixedSampleWindowPolicy:
+    """Select a symmetric sample window, optionally derived from the time span."""
+
+    samples: Optional[int] = None
+    derive_from_window_ms: bool = False
+    symmetric_round: bool = False
+    kind: Literal["fixed_sample"] = "fixed_sample"
+
+
+@dataclass(frozen=True)
+class ShiftedValidWindowPolicy:
+    """Shift a time- or sample-sized window until all included samples are valid."""
+
+    samples: Optional[int] = None
+    derive_from_window_ms: bool = False
+    symmetric_round: bool = False
+    fallback: Literal["shrink", "unclassified"] = "shrink"
+    kind: Literal["shifted_valid"] = "shifted_valid"
+
+
+@dataclass(frozen=True)
+class AsymmetricNeighborWindowPolicy:
+    """Use the immediate backward neighbor with a forward-neighbor fallback."""
+
+    kind: Literal["asymmetric_neighbor"] = "asymmetric_neighbor"
+
+
+@dataclass(frozen=True)
+class TobiiWindowPolicy:
+    """Use Tobii's sample-count calculation for a nominal sample interval."""
+
+    sample_interval_ms: Optional[float] = None
+    kind: Literal["tobii"] = "tobii"
+
+
+WindowPolicy = Union[
+    TimeSymmetricWindowPolicy,
+    SampleSymmetricWindowPolicy,
+    FixedSampleWindowPolicy,
+    ShiftedValidWindowPolicy,
+    AsymmetricNeighborWindowPolicy,
+    TobiiWindowPolicy,
+]
+
+_POLICY_TYPES = {
+    "time_symmetric": TimeSymmetricWindowPolicy,
+    "sample_symmetric": SampleSymmetricWindowPolicy,
+    "fixed_sample": FixedSampleWindowPolicy,
+    "shifted_valid": ShiftedValidWindowPolicy,
+    "asymmetric_neighbor": AsymmetricNeighborWindowPolicy,
+    "tobii": TobiiWindowPolicy,
+}
+
+
+def window_policy_from_dict(data: Mapping[str, Any]) -> WindowPolicy:
+    """Deserialize a tagged window policy persisted in experiment JSON."""
+    values = dict(data)
+    kind = values.pop("kind", None)
+    try:
+        policy_type = _POLICY_TYPES[kind]
+    except KeyError as exc:
+        raise ValueError(f"Unknown window policy kind: {kind!r}") from exc
+    return policy_type(**values)
+
+
+def translate_legacy_window_flags(
+    *,
+    sample_symmetric_window: bool = False,
+    fixed_window_samples: Optional[int] = None,
+    auto_fixed_window_from_ms: bool = False,
+    symmetric_round_window: bool = False,
+    asymmetric_neighbor_window: bool = False,
+    shifted_valid_window: bool = False,
+    shifted_valid_fallback: Literal["shrink", "unclassified"] = "shrink",
+    tobii_window_mode: bool = False,
+    tobii_sample_interval_ms: Optional[float] = None,
+) -> WindowPolicy:
+    """Translate deprecated selector flags into exactly one explicit policy.
+
+    Modifiers for fixed sample sizing remain compatible with each other. Selector
+    modes that used to be silently hidden by precedence are rejected.
+    """
+    fixed_mode = (
+        fixed_window_samples is not None
+        or auto_fixed_window_from_ms
+        or symmetric_round_window
+    )
+    selectors = []
+    if tobii_window_mode:
+        selectors.append("tobii_window_mode")
+    if asymmetric_neighbor_window:
+        selectors.append("asymmetric_neighbor_window")
+    if shifted_valid_window:
+        selectors.append("shifted_valid_window")
+    elif fixed_mode:
+        selectors.append("fixed_window_samples")
+    if sample_symmetric_window:
+        selectors.append("sample_symmetric_window")
+    if len(selectors) > 1:
+        raise ValueError(
+            "Contradictory legacy window flags: "
+            + selectors[0]
+            + " takes precedence over "
+            + ", ".join(selectors[1:])
+            + "; configure exactly one window policy."
+        )
+
+    if tobii_window_mode:
+        return TobiiWindowPolicy(sample_interval_ms=tobii_sample_interval_ms)
+    if asymmetric_neighbor_window:
+        return AsymmetricNeighborWindowPolicy()
+    if shifted_valid_window:
+        return ShiftedValidWindowPolicy(
+            samples=fixed_window_samples,
+            derive_from_window_ms=auto_fixed_window_from_ms,
+            symmetric_round=symmetric_round_window,
+            fallback=shifted_valid_fallback,
+        )
+    if fixed_mode:
+        return FixedSampleWindowPolicy(
+            samples=fixed_window_samples,
+            derive_from_window_ms=auto_fixed_window_from_ms,
+            symmetric_round=symmetric_round_window,
+        )
+    if sample_symmetric_window:
+        return SampleSymmetricWindowPolicy()
+    return TimeSymmetricWindowPolicy()

--- a/ivt_filter/processing/velocity_factory.py
+++ b/ivt_filter/processing/velocity_factory.py
@@ -1,7 +1,15 @@
 """Factories for velocity calculation and window-selection strategies."""
 from __future__ import annotations
 
-from ..config import OlsenVelocityConfig
+from ..config import (
+    AsymmetricNeighborWindowPolicy,
+    FixedSampleWindowPolicy,
+    OlsenVelocityConfig,
+    SampleSymmetricWindowPolicy,
+    ShiftedValidWindowPolicy,
+    TimeSymmetricWindowPolicy,
+    TobiiWindowPolicy,
+)
 from ..strategies import (
     AsymmetricNeighborWindowSelector,
     CoordinateRoundingStrategy,
@@ -45,68 +53,47 @@ def _get_velocity_calculation_strategy(method: str) -> VelocityCalculationStrate
         raise ValueError(f"Unknown velocity calculation method: {method}")
 
 def make_window_selector(cfg: OlsenVelocityConfig) -> WindowSelector:
-    """
-    Waehlt die passende Fenster-Strategie basierend auf der Config.
-    Prioritaet:
-      0) tobii_window_mode (Tobii-exakter GazeVelocityCalculator, höchste Priorität)
-      1) asymmetric_neighbor_window (2-Sample asymmetrisch, Backward/Forward)
-      2) fixed_window_samples (reines Sample-Fenster)
-      3) sample_symmetric_window (Zeit + sample-symmetrisch)
-      4) reines Zeitfenster
-
-    Nutzt WindowRoundingStrategy zur Bestimmung der half_size.
-    """
-    # Tobii-exakter GazeVelocityCalculator (höchste Priorität)
-    if getattr(cfg, "tobii_window_mode", False):
-        sample_interval_ms = getattr(cfg, "tobii_sample_interval_ms", None)
+    """Create the selector described by the normalized tagged window policy."""
+    policy = cfg.window_policy
+    if isinstance(policy, TobiiWindowPolicy):
+        sample_interval_ms = policy.sample_interval_ms
         if sample_interval_ms is None or sample_interval_ms <= 0:
             raise ValueError(
-                "tobii_window_mode requires tobii_sample_interval_ms > 0. "
-                "Set e.g. tobii_sample_interval_ms=16.67 for 60 Hz."
+                "TobiiWindowPolicy requires tobii_sample_interval_ms/sample_interval_ms > 0. "
+                "Set e.g. sample_interval_ms=16.67 for 60 Hz."
             )
         return TobiiGazeVelocityWindowSelector(sample_interval_ms=sample_interval_ms)
-
-    # Asymmetrisches Nachbar-Fenster (2 Samples)
-    if cfg.asymmetric_neighbor_window:
+    if isinstance(policy, AsymmetricNeighborWindowPolicy):
         return AsymmetricNeighborWindowSelector()
 
-    # Select strategy
     rounding_strategy: WindowRoundingStrategy
-    if cfg.symmetric_round_window:
+    if isinstance(policy, (FixedSampleWindowPolicy, ShiftedValidWindowPolicy)) and policy.symmetric_round:
         rounding_strategy = SymmetricRoundWindowStrategy()
     else:
         rounding_strategy = StandardWindowRounding()
 
-    if cfg.shifted_valid_window:
-        if cfg.fixed_window_samples is not None:
-            # Sample-based shifted valid window
-            n = int(cfg.fixed_window_samples)
-            if n < 3:
-                raise ValueError(
-                    "fixed_window_samples must be >= 3 for shifted_valid_window."
-                )
-            half_size = rounding_strategy.calculate_half_size(n)
-            return ShiftedValidWindowSelector(
-                half_size=half_size, fallback_mode=cfg.shifted_valid_fallback
-            )
-        else:
-            # Time-based shifted valid window
-            return TimeBasedShiftedValidWindowSelector(
-                fallback_mode=cfg.shifted_valid_fallback
-            )
-
-    if cfg.fixed_window_samples is not None:
-        n = int(cfg.fixed_window_samples)
-        if n < 3:
-            raise ValueError("fixed_window_samples must be >= 3.")
-
-        half_size = rounding_strategy.calculate_half_size(n)
-        return FixedSampleSymmetricWindowSelector(half_size=half_size)
-
-    if cfg.sample_symmetric_window:
+    if isinstance(policy, ShiftedValidWindowPolicy):
+        if policy.samples is None:
+            return TimeBasedShiftedValidWindowSelector(fallback_mode=policy.fallback)
+        if policy.samples < 3:
+            raise ValueError("samples must be >= 3 for ShiftedValidWindowPolicy.")
+        return ShiftedValidWindowSelector(
+            half_size=rounding_strategy.calculate_half_size(policy.samples),
+            fallback_mode=policy.fallback,
+        )
+    if isinstance(policy, FixedSampleWindowPolicy):
+        if policy.samples is None:
+            raise ValueError("FixedSampleWindowPolicy requires samples >= 3 after derivation.")
+        if policy.samples < 3:
+            raise ValueError("samples must be >= 3 for FixedSampleWindowPolicy.")
+        return FixedSampleSymmetricWindowSelector(
+            half_size=rounding_strategy.calculate_half_size(policy.samples)
+        )
+    if isinstance(policy, SampleSymmetricWindowPolicy):
         return SampleSymmetricWindowSelector()
-
-    return TimeSymmetricWindowSelector()
+    if isinstance(policy, TimeSymmetricWindowPolicy):
+        return TimeSymmetricWindowSelector()
+    raise TypeError(f"Unsupported window policy: {policy!r}")
 
 
 def _get_coordinate_rounding_strategy(mode: str) -> CoordinateRoundingStrategy:

--- a/ivt_filter/processing/velocity_input.py
+++ b/ivt_filter/processing/velocity_input.py
@@ -9,7 +9,7 @@ from typing import Optional
 import numpy as np
 import pandas as pd
 
-from ..config import OlsenVelocityConfig
+from ..config import FixedSampleWindowPolicy, OlsenVelocityConfig, ShiftedValidWindowPolicy
 from ..domain.schema import validate_preprocessed_frame, validate_raw_gaze_frame
 from ..utils.sampling import (
     coerce_finite_timestamps,
@@ -102,14 +102,31 @@ class SamplingAnalyzer:
         if math.isfinite(hz_measured):
             nearest = min(self.NOMINAL_RATES, key=lambda rate: abs(rate - hz_measured))
             logger.info("[Sampling] nearest nominal rate: %.1f Hz", nearest)
-        should_convert = cfg.auto_fixed_window_from_ms or cfg.symmetric_round_window
-        if should_convert and cfg.fixed_window_samples is None and dt_ms > 0:
+        policy = cfg.window_policy
+        should_convert = isinstance(policy, (FixedSampleWindowPolicy, ShiftedValidWindowPolicy)) and (
+            policy.derive_from_window_ms or policy.symmetric_round
+        )
+        if (
+            isinstance(policy, (FixedSampleWindowPolicy, ShiftedValidWindowPolicy))
+            and should_convert
+            and policy.samples is None
+            and dt_ms > 0
+        ):
             intervals = max(1, int(round(cfg.window_length_ms / dt_ms)))
             samples = max(3, intervals + 1)
             if samples % 2 == 0:
                 samples += 1
             effective_ms = (samples - 1) * dt_ms
-            cfg = dataclasses.replace(cfg, fixed_window_samples=samples)
+            effective_policy = dataclasses.replace(policy, samples=samples)
+            if cfg.auto_fixed_window_from_ms or cfg.symmetric_round_window:
+                # Preserve the deprecated field for direct legacy callers only.
+                cfg = dataclasses.replace(
+                    cfg,
+                    fixed_window_samples=samples,
+                    window_policy=effective_policy,
+                )
+            else:
+                cfg = dataclasses.replace(cfg, window_policy=effective_policy)
             logger.info(
                 "[Window] auto sample window: %s samples total (~%.1f pro Seite um "
                 "das Zentrum, effektive Spannweite ~%.2f ms)",

--- a/ivt_filter/processing/velocity_samples.py
+++ b/ivt_filter/processing/velocity_samples.py
@@ -445,7 +445,7 @@ def _compute_olsen_velocity_impl(
     # Fensterbreite in Samples berechnen für Transparenz
     if isinstance(selector, FixedSampleSymmetricWindowSelector):
         # Bei FixedSample: Fensterbreite ist bekannt
-        fixed_samples = cfg.fixed_window_samples
+        fixed_samples = getattr(cfg.window_policy, "samples", None)
         logger.info("Fixed sample window: %s samples", fixed_samples)
     elif isinstance(selector, AsymmetricNeighborWindowSelector):
         # Bei Asymmetrischem Nachbar-Fenster: 2 Samples
@@ -490,10 +490,10 @@ def _compute_olsen_velocity_impl(
         gap_max = 1
     elif (
         isinstance(selector, FixedSampleSymmetricWindowSelector)
-        and cfg.fixed_window_samples is not None
+        and isinstance(getattr(cfg.window_policy, "samples", None), int)
     ):
         # Ursprüngliche Fenstergröße ohne Asymmetrie-Anpassung
-        original_window_size = int(cfg.fixed_window_samples)
+        original_window_size = int(getattr(cfg.window_policy, "samples"))
         gap_max = max(0, original_window_size - 1)
     elif dt_med is not None and dt_med > 0:
         # Ursprüngliche Zeit-basierte Schätzung ohne Asymmetrie-Anpassung

--- a/tests/test_velocity_config_validation.py
+++ b/tests/test_velocity_config_validation.py
@@ -2,7 +2,16 @@ from __future__ import annotations
 
 import pytest
 
-from ivt_filter.config import OlsenVelocityConfig
+from ivt_filter.config import (
+    AsymmetricNeighborWindowPolicy,
+    FixedSampleWindowPolicy,
+    OlsenVelocityConfig,
+    SampleSymmetricWindowPolicy,
+    ShiftedValidWindowPolicy,
+    TimeSymmetricWindowPolicy,
+    TobiiWindowPolicy,
+    WindowPolicy,
+)
 
 
 @pytest.mark.parametrize(
@@ -111,3 +120,89 @@ def test_compatible_legacy_window_modes_keep_existing_selector_behavior(
     selector = make_window_selector(OlsenVelocityConfig(**config_kwargs))
 
     assert type(selector).__name__ == selector_type
+
+@pytest.mark.parametrize(
+    ("policy", "selector_type"),
+    [
+        (TimeSymmetricWindowPolicy(), "TimeSymmetricWindowSelector"),
+        (SampleSymmetricWindowPolicy(), "SampleSymmetricWindowSelector"),
+        (FixedSampleWindowPolicy(samples=5), "FixedSampleSymmetricWindowSelector"),
+        (
+            ShiftedValidWindowPolicy(samples=5, fallback="unclassified"),
+            "ShiftedValidWindowSelector",
+        ),
+        (ShiftedValidWindowPolicy(), "TimeBasedShiftedValidWindowSelector"),
+        (AsymmetricNeighborWindowPolicy(), "AsymmetricNeighborWindowSelector"),
+        (TobiiWindowPolicy(sample_interval_ms=8.33), "TobiiGazeVelocityWindowSelector"),
+    ],
+)
+def test_explicit_window_policy_variants_dispatch_directly(
+    policy: WindowPolicy, selector_type: str
+) -> None:
+    from ivt_filter.processing.velocity import make_window_selector
+
+    selector = make_window_selector(OlsenVelocityConfig(window_policy=policy))
+
+    assert type(selector).__name__ == selector_type
+
+
+def test_experiment_json_persists_and_restores_normalized_window_policy() -> None:
+    from ivt_filter.config import IVTClassifierConfig
+    from ivt_filter.evaluation.experiment import ExperimentConfig
+
+    experiment = ExperimentConfig(
+        name="fixed-window",
+        description="policy persistence",
+        velocity_config=OlsenVelocityConfig(
+            window_policy=FixedSampleWindowPolicy(samples=5, symmetric_round=True)
+        ),
+        classifier_config=IVTClassifierConfig(),
+    )
+
+    serialized = experiment.to_dict()
+    restored = ExperimentConfig.from_dict(serialized)
+
+    assert serialized["velocity_config"]["window_policy"] == {
+        "samples": 5,
+        "derive_from_window_ms": False,
+        "symmetric_round": True,
+        "kind": "fixed_sample",
+    }
+    assert restored.velocity_config.window_policy == FixedSampleWindowPolicy(
+        samples=5, symmetric_round=True
+    )
+
+@pytest.mark.parametrize(
+    "cli_flags",
+    [
+        ["--sample-symmetric-window", "--fixed-window-samples", "5"],
+        ["--sample-symmetric-window", "--shifted-valid-window"],
+        ["--sample-symmetric-window", "--asymmetric-neighbor-window"],
+        ["--fixed-window-samples", "5", "--asymmetric-neighbor-window"],
+        ["--shifted-valid-window", "--asymmetric-neighbor-window"],
+    ],
+)
+def test_config_builder_rejects_contradictory_legacy_cli_flags(
+    cli_flags: list[str],
+) -> None:
+    from ivt_filter.cli import build_arg_parser
+    from ivt_filter.config import ConfigBuilder
+
+    args = build_arg_parser().parse_args(["--input", "gaze.tsv", *cli_flags])
+
+    with pytest.raises(ValueError, match="Contradictory legacy window flags"):
+        ConfigBuilder.build_velocity_config(args)
+
+
+def test_config_builder_translates_legacy_cli_flags_to_one_policy() -> None:
+    from ivt_filter.cli import build_arg_parser
+    from ivt_filter.config import ConfigBuilder
+
+    args = build_arg_parser().parse_args(
+        ["--input", "gaze.tsv", "--fixed-window-samples", "5"]
+    )
+
+    config = ConfigBuilder.build_velocity_config(args)
+
+    assert config.window_policy == FixedSampleWindowPolicy(samples=5)
+    assert config.fixed_window_samples is None


### PR DESCRIPTION
### Motivation

- Replace fragile boolean precedence for velocity window selection with an explicit, serializable policy model so selector behavior is unambiguous and comparable across runs. 
- Allow the CLI to remain stable while translating legacy flag combinations into a single canonical policy and clearly reject contradictory legacy combinations.
- Persist a normalized policy in experiment JSON so experiment provenance encodes the selector choice directly.

### Description

- Introduce a tagged dataclass union for window policies in `ivt_filter/config/window_policy.py` with variants `TimeSymmetricWindowPolicy`, `SampleSymmetricWindowPolicy`, `FixedSampleWindowPolicy`, `ShiftedValidWindowPolicy`, `AsymmetricNeighborWindowPolicy`, and `TobiiWindowPolicy`, plus `window_policy_from_dict` and `translate_legacy_window_flags` helpers.
- Add `window_policy: Optional[WindowPolicy]` to `OlsenVelocityConfig` and normalize legacy boolean flags into exactly one policy in `__post_init__` (accepting a dict form for JSON restore), rejecting contradictory legacy combinations with clear error messages.
- Update `ConfigBuilder.build_velocity_config` to translate CLI legacy flags to a single policy via `translate_legacy_window_flags` and pass `window_policy` into `OlsenVelocityConfig` while keeping the original CLI flags available temporarily.
- Replace boolean precedence logic in `make_window_selector` with policy dispatch in `ivt_filter/processing/velocity_factory.py`, including policy-specific validation (e.g. Tobii requires a positive sample interval, fixed/shifted samples must be >= 3).
- Preserve automatic fixed-sample derivation: `SamplingAnalyzer.analyze` now derives an effective `samples` value and updates the `window_policy` accordingly while preserving the deprecated `fixed_window_samples` field only for direct legacy callers when necessary.
- Persist and restore the normalized policy via experiment JSON using the existing `ExperimentConfig.to_dict` / `from_dict` flow (the policy dataclass is serialized to a dict and deserialized via `window_policy_from_dict`).
- Add focused tests in `tests/test_velocity_config_validation.py` that validate dispatch for each explicit policy variant, JSON round-trip persistence/restoration of the policy, translation of CLI flags into a single policy, and rejection of contradictory legacy CLI flag combinations.

### Testing

- Ran linter and static checks with `ruff` and `mypy` with no reported issues.
- Ran the full test-suite with `pytest -q`, which completed successfully: `323 passed, 2 skipped`.
- Exercised the focused validation tests in `tests/test_velocity_config_validation.py` (policy variants, JSON round-trip, and contradictory-flag rejections) as part of the test run and they passed.
