### PR TITLE
Centralize inclusive event-duration calculations

### DIFF
--- a/ivt_filter/domain/__init__.py
+++ b/ivt_filter/domain/__init__.py
@@ -1,9 +1,12 @@
 """Shared domain rules and lightweight DataFrame stage contracts."""
 
+from .durations import event_duration_ms, estimate_sample_interval_ms
 from .events import iter_contiguous_events, rebuild_events_from_sample_labels
 from .validity import parse_tobii_validity
 
 __all__ = [
+    "estimate_sample_interval_ms",
+    "event_duration_ms",
     "iter_contiguous_events",
     "parse_tobii_validity",
     "rebuild_events_from_sample_labels",

--- a/ivt_filter/domain/durations.py
+++ b/ivt_filter/domain/durations.py
@@ -1,0 +1,48 @@
+"""Shared timestamp-based duration rules for reconstructed I-VT events."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import numpy as np
+
+DEFAULT_SAMPLE_INTERVAL_MS = 1.0
+
+
+def estimate_sample_interval_ms(
+    timestamps_ms: Iterable[float],
+    *,
+    fallback_ms: float = DEFAULT_SAMPLE_INTERVAL_MS,
+) -> float:
+    """Return the robust sample interval used by event-duration calculations.
+
+    The project convention is the median of finite, positive timestamp
+    differences.  A fallback keeps single-sample inputs and degenerate timelines
+    measurable; it preserves the historical 1 ms behavior by default.
+    """
+    timestamps = np.asarray(list(timestamps_ms), dtype=float)
+    diffs = np.diff(timestamps)
+    positive_diffs = diffs[np.isfinite(diffs) & (diffs > 0)]
+    if len(positive_diffs) == 0:
+        return float(fallback_ms)
+    return float(np.median(positive_diffs))
+
+
+def event_duration_ms(
+    timestamps_ms: Iterable[float],
+    *,
+    sample_interval_ms: float | None = None,
+) -> float:
+    """Calculate an event duration using the inclusive-end-sample convention.
+
+    Event samples represent intervals, not zero-width points.  Duration is
+    therefore ``(last_timestamp - first_timestamp) + sample_interval_ms``.  Pass
+    an interval estimated from the complete recording when measuring a slice so
+    single-sample events use the same robust interval as neighboring events.
+    """
+    timestamps = np.asarray(list(timestamps_ms), dtype=float)
+    if len(timestamps) == 0:
+        return 0.0
+    if sample_interval_ms is None:
+        sample_interval_ms = estimate_sample_interval_ms(timestamps)
+    return float(timestamps[-1] - timestamps[0] + sample_interval_ms)

--- a/ivt_filter/evaluation/event_iou.py
+++ b/ivt_filter/evaluation/event_iou.py
@@ -48,7 +48,8 @@ class Event:
     start_idx:      0-based positional index of the first sample (inclusive).
     end_idx:        0-based positional index of the last sample (inclusive).
     start_time_ms:  Timestamp of the first sample in milliseconds.
-    end_time_ms:    Timestamp of the last sample in milliseconds.
+    end_time_ms:    Timestamp of the last sample in milliseconds. This is a
+                    boundary timestamp, not an inclusive event duration.
     n_samples:      Number of samples = end_idx - start_idx + 1.
     """
 

--- a/ivt_filter/postprocessing/discard_short_fixations.py
+++ b/ivt_filter/postprocessing/discard_short_fixations.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 
 from typing import Tuple, Dict, Any, List
 
-import numpy as np
 import pandas as pd
 
 from ..config import FixationPostConfig
+from ..domain.durations import event_duration_ms, estimate_sample_interval_ms
 
 
 def discard_short_fixations(
@@ -35,7 +35,7 @@ def discard_short_fixations(
        - Nicht hardcoded
     
     3) Eventdauer (inklusive Endsample):
-       - duration_ms = (t_last - t_first) + dt_ms
+       - duration_ms = event_duration_ms(times[start_idx : end_idx + 1], sample_interval_ms=dt_ms)
        - +dt_ms ist verpflichtend (verhindert Off-by-one)
     
     Args:
@@ -78,13 +78,7 @@ def discard_short_fixations(
     n = len(df)
     
     # 1) Berechne robustes dt_ms aus time_ms (Median der positiven Differenzen)
-    diffs = np.diff(times)
-    positive_diffs = diffs[diffs > 0]
-    
-    if len(positive_diffs) == 0:
-        dt_ms = 1.0
-    else:
-        dt_ms = float(np.median(positive_diffs))
+    dt_ms = estimate_sample_interval_ms(times)
     
     # 2) Finde alle Fixation-Events anhand von event_type und event_index
     fixation_events: List[Dict[str, Any]] = []
@@ -107,7 +101,7 @@ def discard_short_fixations(
                     end_idx = i - 1
                     t_first = float(times[start_idx])
                     t_last = float(times[end_idx])
-                    duration_ms = (t_last - t_first) + dt_ms
+                    duration_ms = event_duration_ms(times[start_idx : end_idx + 1], sample_interval_ms=dt_ms)
                     
                     fixation_events.append({
                         "event_index": current_event_index,
@@ -129,7 +123,7 @@ def discard_short_fixations(
                 end_idx = i - 1
                 t_first = float(times[start_idx])
                 t_last = float(times[end_idx])
-                duration_ms = (t_last - t_first) + dt_ms
+                duration_ms = event_duration_ms(times[start_idx : end_idx + 1], sample_interval_ms=dt_ms)
                 
                 fixation_events.append({
                     "event_index": current_event_index,
@@ -149,7 +143,7 @@ def discard_short_fixations(
         end_idx = n - 1
         t_first = float(times[start_idx])
         t_last = float(times[end_idx])
-        duration_ms = (t_last - t_first) + dt_ms
+        duration_ms = event_duration_ms(times[start_idx : end_idx + 1], sample_interval_ms=dt_ms)
         
         fixation_events.append({
             "event_index": current_event_index,

--- a/ivt_filter/postprocessing/merge_fixations.py
+++ b/ivt_filter/postprocessing/merge_fixations.py
@@ -122,7 +122,8 @@ def merge_adjacent_fixations(
         s1, e1 = events[idx]
         s2, e2 = events[idx + 1]
 
-        # Zeitabstand zwischen Ende Fix1 und Start Fix2
+        # Zeitabstand zwischen Ende Fix1 und Start Fix2. Dies ist der Abstand
+        # zwischen Event-Grenzen, keine inklusive Eventdauer.
         time_gap = float(times[s2]) - float(times[e1])
         if time_gap <= 0 or time_gap > cfg.max_time_gap_ms:
             continue

--- a/ivt_filter/postprocessing/merge_saccades.py
+++ b/ivt_filter/postprocessing/merge_saccades.py
@@ -7,6 +7,7 @@ from typing import Optional, List, Tuple, Dict, Any
 import pandas as pd
 
 from ..config import SaccadeMergeConfig
+from ..domain.durations import event_duration_ms, estimate_sample_interval_ms
 from ..domain.events import iter_contiguous_events, rebuild_events_from_sample_labels
 
 
@@ -52,6 +53,7 @@ def merge_short_saccade_blocks(
     work_col = sample_col if sample_col is not None else event_col
 
     times = df["time_ms"].to_numpy()
+    sample_interval_ms = estimate_sample_interval_ms(times)
     # GT no longer needed - Post-Smoothing basiert nur auf IVT-Kontext und Dauer
     ivt = df[work_col].astype(str).to_numpy()
 
@@ -70,7 +72,9 @@ def merge_short_saccade_blocks(
     new_ivt = ivt.copy()
 
     for (b_start, b_end) in blocks:
-        duration_ms = float(times[b_end] - times[b_start])
+        duration_ms = event_duration_ms(
+            times[b_start : b_end + 1], sample_interval_ms=sample_interval_ms
+        )
         if duration_ms >= cfg.max_saccade_block_duration_ms:
             continue
 

--- a/tests/test_event_durations.py
+++ b/tests/test_event_durations.py
@@ -1,0 +1,99 @@
+"""Regression tests for the shared inclusive event-duration convention."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from ivt_filter.config import FixationPostConfig, SaccadeMergeConfig
+from ivt_filter.domain.durations import event_duration_ms, estimate_sample_interval_ms
+from ivt_filter.postprocessing.discard_short_fixations import discard_short_fixations
+from ivt_filter.postprocessing.merge_saccades import merge_short_saccade_blocks
+
+
+@pytest.mark.parametrize(
+    ("timestamps_ms", "expected_duration_ms"),
+    [
+        ([100.0], 1.0),
+        ([100.0, 110.0], 20.0),
+        ([0.0, 7.0, 20.0], 30.0),
+    ],
+)
+def test_event_duration_includes_final_sample_interval(
+    timestamps_ms: list[float], expected_duration_ms: float
+) -> None:
+    assert event_duration_ms(timestamps_ms) == expected_duration_ms
+
+
+def test_single_sample_event_can_use_recording_interval() -> None:
+    recording_interval_ms = estimate_sample_interval_ms([0.0, 10.0, 20.0])
+
+    assert event_duration_ms([10.0], sample_interval_ms=recording_interval_ms) == 10.0
+
+
+def _discard_fixation(
+    timestamps_ms: list[float], *, threshold_ms: float
+) -> tuple[pd.DataFrame, dict[str, object]]:
+    df = pd.DataFrame(
+        {
+            "time_ms": timestamps_ms,
+            "ivt_event_type": ["Fixation"] * len(timestamps_ms),
+            "ivt_event_index": [1] * len(timestamps_ms),
+        }
+    )
+    return discard_short_fixations(
+        df,
+        FixationPostConfig(min_fixation_duration_ms=threshold_ms),
+        event_type_col="ivt_event_type",
+        event_index_col="ivt_event_index",
+        time_col="time_ms",
+    )
+
+
+def test_discard_short_fixations_keeps_event_at_exact_threshold() -> None:
+    result, stats = _discard_fixation([0.0, 10.0], threshold_ms=20.0)
+
+    assert result["ivt_event_type"].tolist() == ["Fixation", "Fixation"]
+    assert stats["fixation_events"][0]["duration_ms"] == 20.0
+
+
+def test_discard_short_fixations_discards_event_just_below_threshold() -> None:
+    result, stats = _discard_fixation([0.0, 9.0], threshold_ms=19.0)
+
+    assert result["ivt_event_type"].tolist() == ["Unclassified", "Unclassified"]
+    assert stats["fixation_events"][0]["duration_ms"] == 18.0
+
+
+def test_discard_short_fixations_uses_robust_interval_for_irregular_samples() -> None:
+    result, stats = _discard_fixation([0.0, 7.0, 20.0], threshold_ms=30.0)
+
+    assert result["ivt_event_type"].tolist() == ["Fixation"] * 3
+    assert stats["dt_ms"] == 10.0
+    assert stats["fixation_events"][0]["duration_ms"] == 30.0
+
+
+def _merge_single_sample_saccade(*, threshold_ms: float) -> tuple[pd.DataFrame, dict[str, object]]:
+    df = pd.DataFrame(
+        {
+            "time_ms": [0.0, 10.0, 20.0],
+            "ivt_sample_type": ["Fixation", "Saccade", "Fixation"],
+            "ivt_event_type": ["Fixation", "Saccade", "Fixation"],
+        }
+    )
+    return merge_short_saccade_blocks(
+        df, SaccadeMergeConfig(max_saccade_block_duration_ms=threshold_ms)
+    )
+
+
+def test_merge_short_saccade_blocks_keeps_event_at_exact_threshold() -> None:
+    result, stats = _merge_single_sample_saccade(threshold_ms=10.0)
+
+    assert result["ivt_sample_type_smoothed"].tolist() == ["Fixation", "Saccade", "Fixation"]
+    assert stats["n_blocks_merged"] == 0
+
+
+def test_merge_short_saccade_blocks_merges_event_just_below_threshold() -> None:
+    result, stats = _merge_single_sample_saccade(threshold_ms=10.01)
+
+    assert result["ivt_sample_type_smoothed"].tolist() == ["Fixation"] * 3
+    assert stats["n_blocks_merged"] == 1


### PR DESCRIPTION
### Motivation
- Ensure a single, well-documented convention for event duration (inclusive end-sample) is applied consistently across post-processing routines.
- Fix an inconsistency where short-saccade merging used a plain timestamp span while discard logic used an inclusive convention, which could change boundary decisions for single-sample events.
- Provide deterministic behavior for irregularly sampled data by using a robust sample-interval estimator rather than ad-hoc logic duplicated in multiple places.

### Description
- Add `ivt_filter/domain/durations.py` with `estimate_sample_interval_ms()` (median positive diffs, 1 ms fallback) and `event_duration_ms()` (inclusive-end-sample: `(last - first) + sample_interval_ms`).
- Export the new helpers from `ivt_filter/domain/__init__.py` and refactor `merge_short_saccade_blocks()` to use the shared estimator and `event_duration_ms()` for saccade-block durations.
- Refactor `discard_short_fixations()` to use the shared estimator and `event_duration_ms()` for fixation durations and preserve the documented threshold semantics.
- Clarify (no behavior change) that `event_iou` records boundary timestamps for onset/offset deviation and that `merge_fixations` measures inter-event gap, both intentionally separate from inclusive event-duration semantics.
- Add regression tests `tests/test_event_durations.py` covering single-sample, two-sample, exact-threshold, just-below-threshold, and irregularly sampled events exercising both discard and merge code paths.

### Testing
- Ran focused regression tests with `pytest tests/test_event_durations.py -q`, which passed (9 tests, all passed).
- Ran the full test suite with `pytest`, which succeeded (`341 passed, 2 skipped`).
- All automated checks used in the workflow (test runs) passed.