### PR TITLE
Handle empty processed frames in simple API statistics

### DIFF
--- a/ivt_filter/simple_api.py
+++ b/ivt_filter/simple_api.py
@@ -182,9 +182,14 @@ def get_statistics(df: pd.DataFrame) -> dict:
             - total_samples: Number of data points
             - fixation_count: Number of fixations detected
             - saccade_count: Number of saccades detected
-            - fixation_percentage: Percentage of time spent in fixations
-            - avg_velocity: Average eye movement velocity
-            - max_velocity: Maximum velocity observed
+            - fixation_percentage: Percentage of samples classified as fixations
+            - saccade_percentage: Percentage of samples classified as saccades
+            - avg_velocity: Average eye movement velocity, if the velocity column exists
+            - max_velocity: Maximum velocity observed, if the velocity column exists
+            - median_velocity: Median velocity observed, if the velocity column exists
+
+        Empty DataFrames return zero classification percentages. If an empty
+        DataFrame includes the velocity column, its velocity aggregates are NaN.
     
     Example:
         >>> df = process_eye_tracking("data.tsv")
@@ -203,8 +208,12 @@ def get_statistics(df: pd.DataFrame) -> dict:
     stats["saccade_count"] = (df["ivt_sample_type"] == "Saccade").sum()
     
     # Percentages
-    stats["fixation_percentage"] = (stats["fixation_count"] / stats["total_samples"]) * 100  # type: ignore[assignment]
-    stats["saccade_percentage"] = (stats["saccade_count"] / stats["total_samples"]) * 100  # type: ignore[assignment]
+    if stats["total_samples"] == 0:
+        stats["fixation_percentage"] = 0.0
+        stats["saccade_percentage"] = 0.0
+    else:
+        stats["fixation_percentage"] = (stats["fixation_count"] / stats["total_samples"]) * 100
+        stats["saccade_percentage"] = (stats["saccade_count"] / stats["total_samples"]) * 100
     
     # Velocity statistics  
     vel_col = "velocity_deg_per_sec"  # Standard column name from velocity.py

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -236,6 +236,37 @@ def test_import_get_statistics() -> None:
     assert callable(get_statistics)
 
 
+def test_get_statistics_returns_zero_counts_and_percentages_for_empty_dataframe() -> None:
+    from ivt_filter.simple_api import get_statistics
+
+    stats = get_statistics(pd.DataFrame({"ivt_sample_type": pd.Series(dtype="object")}))
+
+    assert stats == {
+        "total_samples": 0,
+        "fixation_count": 0,
+        "saccade_count": 0,
+        "fixation_percentage": 0.0,
+        "saccade_percentage": 0.0,
+    }
+
+
+def test_get_statistics_returns_nan_velocity_aggregates_for_empty_dataframe() -> None:
+    from ivt_filter.simple_api import get_statistics
+
+    stats = get_statistics(
+        pd.DataFrame(
+            {
+                "ivt_sample_type": pd.Series(dtype="object"),
+                "velocity_deg_per_sec": pd.Series(dtype="float64"),
+            }
+        )
+    )
+
+    assert pd.isna(stats["avg_velocity"])
+    assert pd.isna(stats["max_velocity"])
+    assert pd.isna(stats["median_velocity"])
+
+
 def test_import_print_statistics() -> None:
     from ivt_filter.simple_api import print_statistics
 


### PR DESCRIPTION
### Motivation
- Avoid division-by-zero and provide stable, documented behavior when `get_statistics` is called with an empty processed DataFrame.
- Make velocity aggregate behavior for empty frames explicit so callers can rely on either omitted aggregates or pandas `NaN` values.
- Add regression coverage to ensure public API remains stable for empty-frame inputs.

### Description
- Update `ivt_filter/simple_api.py::get_statistics` to return `0.0` for `fixation_percentage` and `saccade_percentage` when `len(df) == 0` instead of performing a division. 
- Documented that empty DataFrames return zero classification percentages and that if `velocity_deg_per_sec` is present its aggregates are computed by pandas (resulting in `NaN` for empty series). 
- Added two tests in `tests/test_public_api.py` to assert stable zero counts/percentages for an empty DataFrame with an `ivt_sample_type` column and to assert `NaN` velocity aggregates when an empty `velocity_deg_per_sec` column is provided.

### Testing
- Ran `pytest tests/test_public_api.py`, which passed (`58 passed, 1 skipped`).
- Ran the full test suite with `pytest`, which passed (`343 passed, 2 skipped`).
