### PR TITLE
Validate IVT pipeline configuration values

### DIFF
--- a/ivt_filter/config/config.py
+++ b/ivt_filter/config/config.py
@@ -34,13 +34,56 @@ Beispiel:
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
+from numbers import Integral, Real
 from typing import Literal, Optional
 
 from .window_policy import (
+    FixedSampleWindowPolicy,
+    ShiftedValidWindowPolicy,
+    TobiiWindowPolicy,
     WindowPolicy,
     translate_legacy_window_flags,
     window_policy_from_dict,
 )
+
+
+def _require_choice(name: str, value: object, choices: tuple[object, ...]) -> None:
+    if value not in choices:
+        raise ValueError(f"{name} must be one of {choices}, got {value!r}")
+
+
+def _require_non_negative(name: str, value: Real) -> None:
+    if not isinstance(value, Real) or not math.isfinite(value) or value < 0:
+        raise ValueError(f"{name} must be non-negative")
+
+
+def _require_positive(name: str, value: Real) -> None:
+    if not isinstance(value, Real) or not math.isfinite(value) or value <= 0:
+        raise ValueError(f"{name} must be positive")
+
+
+def _require_non_negative_integer(name: str, value: int) -> None:
+    if not isinstance(value, Integral) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+
+
+def _require_positive_integer(name: str, value: int) -> None:
+    if not isinstance(value, Integral) or isinstance(value, bool) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+
+
+def _require_positive_odd_samples(name: str, value: int) -> None:
+    _require_positive_integer(name, value)
+    if value % 2 == 0:
+        raise ValueError(f"{name} must be a positive odd integer")
+
+
+def _require_fixed_window_samples(name: str, value: int, *, allow_even: bool) -> None:
+    if not isinstance(value, Integral) or isinstance(value, bool) or value < 3:
+        raise ValueError(f"{name} must be an integer >= 3")
+    if not allow_even and value % 2 == 0:
+        raise ValueError(f"{name} must be odd unless allow_asymmetric_window=True")
 
 
 @dataclass
@@ -216,7 +259,31 @@ class OlsenVelocityConfig:
     tobii_eye_offset_interpolation: bool = False
 
     def __post_init__(self) -> None:
-        """Normalize deprecated selector flags into one tagged window policy."""
+        """Validate values and normalize deprecated selector flags into one policy."""
+        _require_positive("window_length_ms", self.window_length_ms)
+        _require_positive("min_dt_ms", self.min_dt_ms)
+        _require_non_negative_integer("max_validity", self.max_validity)
+        _require_positive_odd_samples("smoothing_window_samples", self.smoothing_window_samples)
+        _require_positive_integer("smoothing_min_samples", self.smoothing_min_samples)
+        _require_non_negative_integer("smoothing_expansion_radius", self.smoothing_expansion_radius)
+        _require_non_negative("gap_fill_max_gap_ms", self.gap_fill_max_gap_ms)
+        _require_choice("time_unit", self.time_unit, ("ms", "us", "ns"))
+        _require_choice("eye_mode", self.eye_mode, ("left", "right", "average"))
+        _require_choice("smoothing_mode", self.smoothing_mode, (
+            "none", "median", "moving_average", "median_strict",
+            "moving_average_strict", "median_adaptive", "moving_average_adaptive",
+        ))
+        _require_choice("sampling_rate_method", self.sampling_rate_method, ("all_samples", "first_100"))
+        _require_choice("dt_calculation_method", self.dt_calculation_method, ("median", "mean"))
+        _require_choice("coordinate_rounding", self.coordinate_rounding, ("none", "nearest", "halfup", "floor", "ceil"))
+        _require_choice("velocity_method", self.velocity_method, ("olsen2d", "ray3d", "ray3d_gaze_dir", "tobii_gaze_dir"))
+        _require_choice("shifted_valid_fallback", self.shifted_valid_fallback, ("shrink", "unclassified"))
+        if self.fixed_window_samples is not None:
+            _require_fixed_window_samples(
+                "fixed_window_samples", self.fixed_window_samples,
+                allow_even=self.allow_asymmetric_window,
+            )
+
         legacy_policy = translate_legacy_window_flags(
             sample_symmetric_window=self.sample_symmetric_window,
             fixed_window_samples=self.fixed_window_samples,
@@ -236,6 +303,19 @@ class OlsenVelocityConfig:
             raise ValueError(
                 "window_policy cannot be combined with contradictory deprecated legacy window flags."
             )
+
+        policy = self.window_policy
+        if isinstance(policy, (FixedSampleWindowPolicy, ShiftedValidWindowPolicy)):
+            _require_choice("window_policy.fallback", getattr(policy, "fallback", "shrink"), ("shrink", "unclassified"))
+            if policy.samples is not None:
+                _require_fixed_window_samples(
+                    "window_policy.samples", policy.samples,
+                    allow_even=self.allow_asymmetric_window,
+                )
+        if isinstance(policy, TobiiWindowPolicy):
+            if policy.sample_interval_ms is None:
+                raise ValueError("Tobii window mode requires tobii_sample_interval_ms/sample_interval_ms")
+            _require_positive("tobii_sample_interval_ms/sample_interval_ms", policy.sample_interval_ms)
 
 
 @dataclass
@@ -289,6 +369,22 @@ class IVTClassifierConfig:
     confident_switch_margin_deg: float = 4.0
     confident_switch_method: Literal["olsen2d", "ray3d", "ray3d_gaze_dir"] = "ray3d_gaze_dir"
 
+    def __post_init__(self) -> None:
+        _require_positive("velocity_threshold_deg_per_sec", self.velocity_threshold_deg_per_sec)
+        for name in (
+            "hysteresis_width_deg_per_sec", "near_threshold_band",
+            "near_threshold_confidence_margin", "near_threshold_max_delta",
+            "eye_jump_threshold_mm", "eye_jump_velocity_threshold",
+            "confident_switch_margin_deg",
+        ):
+            _require_non_negative(name, getattr(self, name))
+        for name in ("near_threshold_band_lower", "near_threshold_band_upper"):
+            value = getattr(self, name)
+            if value is not None:
+                _require_non_negative(name, value)
+        _require_choice("near_threshold_strategy", self.near_threshold_strategy, ("replace", "inverse"))
+        _require_choice("confident_switch_method", self.confident_switch_method, ("olsen2d", "ray3d", "ray3d_gaze_dir"))
+
 
 @dataclass
 class SaccadeMergeConfig:
@@ -308,6 +404,9 @@ class SaccadeMergeConfig:
     # - "ivt_sample_type": sample-basiert, danach Events neu bauen
     # - None: direkt auf "ivt_event_type"
     use_sample_type_column: Optional[str] = "ivt_sample_type"
+
+    def __post_init__(self) -> None:
+        _require_positive("max_saccade_block_duration_ms", self.max_saccade_block_duration_ms)
 
 
 @dataclass
@@ -338,6 +437,15 @@ class FixationPostConfig:
     min_fixation_duration_ms: float = 60.0  # z.B. 60 ms Mindestdauer
     discard_target: Literal["Unclassified", "Saccade"] = "Unclassified"  # Ziel-Label für verworfene Fixationen
 
+    def __post_init__(self) -> None:
+        for name in (
+            "max_time_gap_ms", "max_angle_deg", "max_gap_velocity_deg_per_sec",
+            "min_fixation_duration_ms",
+        ):
+            _require_non_negative(name, getattr(self, name))
+        _require_choice("merge_weighting", self.merge_weighting, ("uniform", "sample_count"))
+        _require_choice("discard_target", self.discard_target, ("Unclassified", "Saccade"))
+
 
 @dataclass(frozen=True)
 class PipelineConfig:
@@ -357,8 +465,6 @@ class PipelineConfig:
     def __post_init__(self) -> None:
         if not self.classify and (self.saccade_merge or self.fixation_post):
             raise ValueError("Post-processing stages require classification")
-        if self.saccade_merge and self.saccade_merge.max_saccade_block_duration_ms <= 0:
-            raise ValueError("Saccade merge duration must be positive")
         if self.fixation_post and not (
             self.fixation_post.merge_adjacent_fixations
             or self.fixation_post.discard_short_fixations

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -171,3 +171,52 @@ def test_pipeline_config_rejects_inactive_optional_stage_config() -> None:
             classifier=IVTClassifierConfig(),
             fixation_post=FixationPostConfig(),
         )
+
+
+@pytest.mark.parametrize(
+    ("config_type", "config_kwargs"),
+    [
+        (IVTClassifierConfig, {"velocity_threshold_deg_per_sec": 0.0}),
+        (IVTClassifierConfig, {"hysteresis_width_deg_per_sec": -1.0}),
+        (IVTClassifierConfig, {"near_threshold_strategy": "unknown"}),
+        (IVTClassifierConfig, {"confident_switch_method": "unknown"}),
+        (SaccadeMergeConfig, {"max_saccade_block_duration_ms": 0.0}),
+        (FixationPostConfig, {"max_time_gap_ms": -1.0}),
+        (FixationPostConfig, {"max_angle_deg": -1.0}),
+        (FixationPostConfig, {"max_gap_velocity_deg_per_sec": -1.0}),
+        (FixationPostConfig, {"min_fixation_duration_ms": -1.0}),
+        (FixationPostConfig, {"merge_weighting": "unknown"}),
+        (FixationPostConfig, {"discard_target": "unknown"}),
+    ],
+)
+def test_stage_configs_reject_boundary_and_enum_like_values(
+    config_type: type[object], config_kwargs: dict[str, object]
+) -> None:
+    with pytest.raises(ValueError):
+        config_type(**config_kwargs)
+
+
+def test_stage_configs_accept_minimum_valid_values() -> None:
+    classifier = IVTClassifierConfig(
+        velocity_threshold_deg_per_sec=0.001,
+        hysteresis_width_deg_per_sec=0.0,
+        near_threshold_band=0.0,
+        near_threshold_band_lower=0.0,
+        near_threshold_band_upper=0.0,
+        near_threshold_confidence_margin=0.0,
+        near_threshold_max_delta=0.0,
+        eye_jump_threshold_mm=0.0,
+        eye_jump_velocity_threshold=0.0,
+        confident_switch_margin_deg=0.0,
+    )
+    saccade = SaccadeMergeConfig(max_saccade_block_duration_ms=0.001)
+    fixation = FixationPostConfig(
+        max_time_gap_ms=0.0,
+        max_angle_deg=0.0,
+        max_gap_velocity_deg_per_sec=0.0,
+        min_fixation_duration_ms=0.0,
+    )
+
+    assert classifier.velocity_threshold_deg_per_sec == 0.001
+    assert saccade.max_saccade_block_duration_ms == 0.001
+    assert fixation.min_fixation_duration_ms == 0.0

--- a/tests/test_tobii_compat.py
+++ b/tests/test_tobii_compat.py
@@ -759,12 +759,9 @@ class TestTobiiConfigFields:
         assert cfg.tobii_eye_offset_interpolation is False
 
     def test_tobii_window_mode_requires_sample_interval(self):
-        """make_window_selector() löst ValueError aus wenn tobii_window_mode=True
-        aber tobii_sample_interval_ms nicht gesetzt."""
-        from ivt_filter.processing.velocity import make_window_selector
-        cfg = OlsenVelocityConfig(tobii_window_mode=True, tobii_sample_interval_ms=None)
+        """Die Config lehnt Tobii-Fenster ohne Sample-Intervall ab."""
         with pytest.raises(ValueError, match="tobii_sample_interval_ms"):
-            make_window_selector(cfg)
+            OlsenVelocityConfig(tobii_window_mode=True, tobii_sample_interval_ms=None)
 
     def test_make_window_selector_returns_tobii_selector(self):
         """make_window_selector() gibt TobiiGazeVelocityWindowSelector zurück."""

--- a/tests/test_velocity_config_validation.py
+++ b/tests/test_velocity_config_validation.py
@@ -206,3 +206,69 @@ def test_config_builder_translates_legacy_cli_flags_to_one_policy() -> None:
 
     assert config.window_policy == FixedSampleWindowPolicy(samples=5)
     assert config.fixed_window_samples is None
+
+
+@pytest.mark.parametrize(
+    "config_kwargs",
+    [
+        {"window_length_ms": 0.0},
+        {"min_dt_ms": 0.0},
+        {"fixed_window_samples": 2},
+        {"fixed_window_samples": 4},
+        {"smoothing_window_samples": 0},
+        {"smoothing_window_samples": 2},
+        {"smoothing_min_samples": 0},
+        {"smoothing_min_samples": 1.5},
+        {"smoothing_expansion_radius": -1},
+        {"smoothing_expansion_radius": 1.5},
+        {"gap_fill_max_gap_ms": -1.0},
+        {"tobii_window_mode": True, "tobii_sample_interval_ms": 0.0},
+        {"window_policy": TobiiWindowPolicy(sample_interval_ms=-1.0)},
+    ],
+)
+def test_velocity_config_rejects_numeric_boundary_values(
+    config_kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        OlsenVelocityConfig(**config_kwargs)
+
+
+@pytest.mark.parametrize(
+    "config_kwargs",
+    [
+        {"time_unit": "seconds"},
+        {"eye_mode": "both"},
+        {"smoothing_mode": "average"},
+        {"sampling_rate_method": "last_100"},
+        {"dt_calculation_method": "minimum"},
+        {"coordinate_rounding": "truncate"},
+        {"velocity_method": "unknown"},
+        {"shifted_valid_fallback": "nearest"},
+    ],
+)
+def test_velocity_config_rejects_unknown_enum_like_values(
+    config_kwargs: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError):
+        OlsenVelocityConfig(**config_kwargs)
+
+
+def test_velocity_config_accepts_minimum_valid_values() -> None:
+    config = OlsenVelocityConfig(
+        window_length_ms=0.001,
+        min_dt_ms=0.001,
+        fixed_window_samples=3,
+        smoothing_window_samples=1,
+        smoothing_min_samples=1,
+        smoothing_expansion_radius=0,
+        gap_fill_max_gap_ms=0.0,
+    )
+
+    assert config.fixed_window_samples == 3
+    assert config.smoothing_window_samples == 1
+
+
+def test_velocity_config_accepts_even_fixed_window_when_asymmetry_is_enabled() -> None:
+    config = OlsenVelocityConfig(fixed_window_samples=4, allow_asymmetric_window=True)
+
+    assert config.fixed_window_samples == 4


### PR DESCRIPTION
### Motivation
- Prevent invalid configuration combinations and out-of-range numeric values from propagating into runtime behavior by surfacing errors at dataclass initialization.
- Ensure Tobii-specific mode and window policies enforce required numeric invariants (e.g. positive sample intervals) rather than relying on downstream factories.
- Keep cross-stage compatibility checks centralized in the `PipelineConfig` post-init while adding per-stage guards to protect direct callers.

### Description
- Add reusable validation helpers (`_require_choice`, `_require_non_negative`, `_require_positive`, `_require_non_negative_integer`, `_require_positive_integer`, `_require_positive_odd_samples`, `_require_fixed_window_samples`) in `ivt_filter/config/config.py`.
- Extend `OlsenVelocityConfig.__post_init__()` to validate timing and numeric invariants, smoothing parameters, fixed-window sizing rules, enum-like fields, normalized `window_policy` values, and require positive Tobii sample intervals when Tobii mode is selected.
- Add `__post_init__()` validation routines for `IVTClassifierConfig` (positive threshold, non-negative numeric params, and enum-like strategy choices), `SaccadeMergeConfig` (positive `max_saccade_block_duration_ms`), and `FixationPostConfig` (non-negative merge/discard parameters and enum-like choices).
- Retain cross-stage checks in `PipelineConfig.__post_init__()` and remove the duplicated saccade-duration check from there to avoid redundancy.
- Add parameterized tests to exercise rejected boundary values and accepted minimums: updates in `tests/test_velocity_config_validation.py`, `tests/test_pipeline_config.py`, and a small change in `tests/test_tobii_compat.py` to assert config-level rejection for missing Tobii sample interval.

### Testing
- Ran targeted validation tests with `python -m pytest tests/test_velocity_config_validation.py tests/test_pipeline_config.py tests/test_tobii_compat.py -q`, which passed.
- Ran the full test suite with `python -m pytest -q`, which reported success (`376 passed, 2 skipped`).