### PR TITLE
Fix mypy errors in numeric config validators

### DIFF
--- a/ivt_filter/config/config.py
+++ b/ivt_filter/config/config.py
@@ -53,12 +53,12 @@ def _require_choice(name: str, value: object, choices: tuple[object, ...]) -> No
         raise ValueError(f"{name} must be one of {choices}, got {value!r}")
 
 
-def _require_non_negative(name: str, value: Real) -> None:
+def _require_non_negative(name: str, value: object) -> None:
     if not isinstance(value, Real) or not math.isfinite(value) or value < 0:
         raise ValueError(f"{name} must be non-negative")
 
 
-def _require_positive(name: str, value: Real) -> None:
+def _require_positive(name: str, value: object) -> None:
     if not isinstance(value, Real) or not math.isfinite(value) or value <= 0:
         raise ValueError(f"{name} must be positive")
 


### PR DESCRIPTION
### Motivation
- Resolve mypy failures caused by annotating numeric validation helpers with `numbers.Real`, which triggers PEP 484 numeric-tower issues during static checking.

### Description
- Update the static parameter types of `_require_non_negative` and `_require_positive` in `ivt_filter/config/config.py` from `Real` to `object` while keeping the runtime `isinstance(..., Real)` and `math.isfinite` checks to preserve validation behavior.

### Testing
- Ran `mypy ivt_filter` (no issues) and `pytest` which completed with `378` passed and `2` skipped.

