### PR TITLE
Refactor CLI argument parser helpers

### DIFF
--- a/ivt_filter/cli.py
+++ b/ivt_filter/cli.py
@@ -16,7 +16,7 @@ from .io.pipeline import IVTPipeline
 
 def build_arg_parser() -> argparse.ArgumentParser:
     """Build CLI argument parser.
-    
+
     Responsibility: Only parsing and describing options (SRP).
     No business logic.
     """
@@ -27,6 +27,19 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "post-processing (gap-filling, smoothing, Tobii-like fixation filters)."
         ),
     )
+    _add_io_arguments(parser)
+    _add_velocity_arguments(parser)
+    _add_window_arguments(parser)
+    _add_smoothing_arguments(parser)
+    _add_classifier_arguments(parser)
+    _add_refinement_arguments(parser)
+    _add_postprocessing_arguments(parser)
+    _add_evaluation_arguments(parser)
+    _add_plotting_arguments(parser)
+    return parser
+
+
+def _add_io_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--input",
         required=True,
@@ -60,13 +73,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Einheit der gewählten Zeitspalte (default: ms).",
     )
 
-    # Velocity / Fenster-Konfiguration
-    parser.add_argument(
-        "--window",
-        type=float,
-        default=20.0,
-        help="Zeitfenster-Laenge in ms fuer Olsen-Window (default: 20.0).",
-    )
+
+def _add_velocity_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--eye",
         choices=["left", "right", "average"],
@@ -74,36 +82,98 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Eye-Selection-Mode (default: average).",
     )
     parser.add_argument(
-        "--smoothing",
-        choices=[
-            "none", "median", "moving_average", 
-            "median_strict", "moving_average_strict",
-            "median_adaptive", "moving_average_adaptive"
-        ],
+        "--sampling-rate-method",
+        choices=["all_samples", "first_100"],
+        default="first_100",
+        help=(
+            "Methode zur Bestimmung der Sampling-Rate. "
+            "'all_samples' (Standard): Alle Samples verwenden. "
+            "'first_100': (standarsyd) Nur die ersten 100 Samples verwenden (wie im Tobii-Paper)."
+        ),
+    )
+    parser.add_argument(
+        "--dt-calculation-method",
+        choices=["median", "mean"],
+        default="median",
+        help=(
+            "Methode zur Berechnung der Zeitdifferenzen. "
+            "'median' (Standard): Robuster gegenüber Ausreißern. "
+            "'mean': Arithmetisches Mittel (wie im Tobii-Paper erwähnt)."
+        ),
+    )
+    parser.add_argument(
+        "--no-fallback-valid-samples",
+        action="store_true",
+        help="Bei ungültigen first/last Samples: nächstes gültiges Sample verwenden (Standard: an).",
+    )
+    # Average-Auge Strategien
+    parser.add_argument(
+        "--average-window-single-eye",
+        action="store_true",
+        help=(
+            "Bei Mixed mono/binokular innerhalb eines Fensters das Auge mit "
+            "stabilerer Validitaet fuer Start/Ende verwenden."
+        ),
+    )
+    parser.add_argument(
+        "--average-window-impute-neighbor",
+        action="store_true",
+        help=(
+            "Fehlende Augenkoordinate am Fensterrand anhand naechstem Nachbarn "
+            "mit gueltigem Auge imputieren (nur eye_mode=average)."
+        ),
+    )
+    parser.add_argument(
+        "--average-fallback-single-eye",
+        action="store_true",
+        help=(
+            "Wenn im Fenster oder mittleren Sample nur ein Auge valide ist, "
+            "verwende durchgehend NUR dieses Auge (kein Average). "
+            "Verhindert Parallaxe-Effekte bei Augen-Wechsel."
+        ),
+    )
+    parser.add_argument(
+        "--coordinate-rounding",
+        choices=["none", "nearest", "halfup", "floor", "ceil"],
         default="none",
-        help="Raeumliches Smoothing auf kombinierten Gaze-Koordinaten. "
-             "_strict Varianten ueberspringen Smoothing wenn invalide Samples im Fenster, "
-             "_adaptive sammelt nur gueltige Samples und kann Suche erweitern (default: none).",
+        help=(
+            "Rundet Gaze/Eye-Koordinaten vor der Velocity-Berechnung auf ganze Zahlen. "
+            "'none': keine Rundung (default), "
+            "'nearest': Banker's Rounding (bei 0.5 zur geraden Zahl), "
+            "'halfup': bei 0.5 immer aufrunden, "
+            "'floor': immer abrunden, "
+            "'ceil': immer aufrunden."
+        ),
     )
     parser.add_argument(
-        "--smooth-window-samples",
-        type=int,
-        default=5,
-        help="Fensterbreite in Samples fuer Smoothing (default: 5).",
+        "--tobii-eye-offset-interpolation",
+        action="store_true",
+        help=(
+            "Rekonstruiert fehlendes Auge via zuletzt bekanntem L→R Versatz "
+            "(Tobii-Referenzlogik). Verhindert Phantom-Velocities an Gap-Rändern "
+            "wenn ein Auge kurzzeitig ausfällt."
+        ),
     )
     parser.add_argument(
-        "--smoothing-min-samples",
-        type=int,
-        default=1,
-        help="(Nur adaptive) Mindestanzahl gueltiger Samples fuer Smoothing (default: 1).",
-    )
-    parser.add_argument(
-        "--smoothing-expansion-radius",
-        type=int,
-        default=0,
-        help="(Nur adaptive) Samples ueber Standard-Fenster hinaus durchsuchen (default: 0).",
+        "--velocity-method",
+        choices=["olsen2d", "ray3d", "ray3d_gaze_dir", "tobii_gaze_dir"],
+        default="olsen2d",
+        help=(
+            "Methode zur Berechnung des visuellen Winkels zwischen zwei Gaze-Punkten. "
+            "'olsen2d': Olsen's 2D-Approximation (tan(θ)=s/d, nur eye_z nötig, schnell), "
+            "'ray3d': physikalisch korrekte 3D-Winkel-Methode (acos(ray0·ray1), benötigt eye_x/y/z, präziser), "
+            "'ray3d_gaze_dir': nutzt normalisierte Blickrichtungs-Vektoren (DACS norm), acos(dir0·dir1); benötigt keine Bildschirm- oder Eye-Position."
+        ),
     )
 
+
+def _add_window_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--window",
+        type=float,
+        default=20.0,
+        help="Zeitfenster-Laenge in ms fuer Olsen-Window (default: 20.0).",
+    )
     # Fenster-Strategien
     parser.add_argument(
         "--sample-symmetric-window",
@@ -188,105 +258,42 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "Vermeidet Jitter durch Rundung. Nur mit --asymmetric-neighbor-window."
         ),
     )
-    parser.add_argument(
-        "--sampling-rate-method",
-        choices=["all_samples", "first_100"],
-        default="first_100",
-        help=(
-            "Methode zur Bestimmung der Sampling-Rate. "
-            "'all_samples' (Standard): Alle Samples verwenden. "
-            "'first_100': (standarsyd) Nur die ersten 100 Samples verwenden (wie im Tobii-Paper)."
-        ),
-    )
-    parser.add_argument(
-        "--dt-calculation-method",
-        choices=["median", "mean"],
-        default="median",
-        help=(
-            "Methode zur Berechnung der Zeitdifferenzen. "
-            "'median' (Standard): Robuster gegenüber Ausreißern. "
-            "'mean': Arithmetisches Mittel (wie im Tobii-Paper erwähnt)."
-        ),
-    )
-    parser.add_argument(
-        "--no-fallback-valid-samples",
-        action="store_true",
-        help="Bei ungültigen first/last Samples: nächstes gültiges Sample verwenden (Standard: an).",
-    )
 
-    # Average-Auge Strategien
-    parser.add_argument(
-        "--average-window-single-eye",
-        action="store_true",
-        help=(
-            "Bei Mixed mono/binokular innerhalb eines Fensters das Auge mit "
-            "stabilerer Validitaet fuer Start/Ende verwenden."
-        ),
-    )
-    parser.add_argument(
-        "--average-window-impute-neighbor",
-        action="store_true",
-        help=(
-            "Fehlende Augenkoordinate am Fensterrand anhand naechstem Nachbarn "
-            "mit gueltigem Auge imputieren (nur eye_mode=average)."
-        ),
-    )
-    parser.add_argument(
-        "--average-fallback-single-eye",
-        action="store_true",
-        help=(
-            "Wenn im Fenster oder mittleren Sample nur ein Auge valide ist, "
-            "verwende durchgehend NUR dieses Auge (kein Average). "
-            "Verhindert Parallaxe-Effekte bei Augen-Wechsel."
-        ),
-    )
 
-    # Gap-Filling
+def _add_smoothing_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
-        "--gap-fill",
-        action="store_true",
-        help="Aktiviere zeitliches Gap-Filling (Interpolation pro Auge).",
-    )
-    parser.add_argument(
-        "--gap-fill-max-ms",
-        type=float,
-        default=75.0,
-        help="Maximale Luecken-Dauer in ms, die per Interpolation gefuellt wird (default: 75).",
-    )
-    parser.add_argument(
-        "--coordinate-rounding",
-        choices=["none", "nearest", "halfup", "floor", "ceil"],
+        "--smoothing",
+        choices=[
+            "none", "median", "moving_average", 
+            "median_strict", "moving_average_strict",
+            "median_adaptive", "moving_average_adaptive"
+        ],
         default="none",
-        help=(
-            "Rundet Gaze/Eye-Koordinaten vor der Velocity-Berechnung auf ganze Zahlen. "
-            "'none': keine Rundung (default), "
-            "'nearest': Banker's Rounding (bei 0.5 zur geraden Zahl), "
-            "'halfup': bei 0.5 immer aufrunden, "
-            "'floor': immer abrunden, "
-            "'ceil': immer aufrunden."
-        ),
+        help="Raeumliches Smoothing auf kombinierten Gaze-Koordinaten. "
+             "_strict Varianten ueberspringen Smoothing wenn invalide Samples im Fenster, "
+             "_adaptive sammelt nur gueltige Samples und kann Suche erweitern (default: none).",
     )
     parser.add_argument(
-        "--tobii-eye-offset-interpolation",
-        action="store_true",
-        help=(
-            "Rekonstruiert fehlendes Auge via zuletzt bekanntem L→R Versatz "
-            "(Tobii-Referenzlogik). Verhindert Phantom-Velocities an Gap-Rändern "
-            "wenn ein Auge kurzzeitig ausfällt."
-        ),
+        "--smooth-window-samples",
+        type=int,
+        default=5,
+        help="Fensterbreite in Samples fuer Smoothing (default: 5).",
     )
     parser.add_argument(
-        "--velocity-method",
-        choices=["olsen2d", "ray3d", "ray3d_gaze_dir", "tobii_gaze_dir"],
-        default="olsen2d",
-        help=(
-            "Methode zur Berechnung des visuellen Winkels zwischen zwei Gaze-Punkten. "
-            "'olsen2d': Olsen's 2D-Approximation (tan(θ)=s/d, nur eye_z nötig, schnell), "
-            "'ray3d': physikalisch korrekte 3D-Winkel-Methode (acos(ray0·ray1), benötigt eye_x/y/z, präziser), "
-            "'ray3d_gaze_dir': nutzt normalisierte Blickrichtungs-Vektoren (DACS norm), acos(dir0·dir1); benötigt keine Bildschirm- oder Eye-Position."
-        ),
+        "--smoothing-min-samples",
+        type=int,
+        default=1,
+        help="(Nur adaptive) Mindestanzahl gueltiger Samples fuer Smoothing (default: 1).",
+    )
+    parser.add_argument(
+        "--smoothing-expansion-radius",
+        type=int,
+        default=0,
+        help="(Nur adaptive) Samples ueber Standard-Fenster hinaus durchsuchen (default: 0).",
     )
 
+
+def _add_classifier_arguments(parser: argparse.ArgumentParser) -> None:
     # Klassifikation
     parser.add_argument(
         "--classify",
@@ -302,7 +309,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default=30.0,
         help="Velocity-Threshold in deg/s fuer I-VT (default: 30).",
     )
-    
+
     # Optional classifier reconstruction heuristics
     parser.add_argument(
         "--enable-invalid-window-neighbor-confirmation",
@@ -327,6 +334,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Width of the optional hysteresis band in deg/s (default: 2.0).",
     )
 
+
+def _add_refinement_arguments(parser: argparse.ArgumentParser) -> None:
     # Near-threshold hybrid strategy
     parser.add_argument(
         "--enable-near-threshold-hybrid",
@@ -417,7 +426,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default="ray3d_gaze_dir",
         help="Alternative velocity method to consult for confident switches (default: ray3d_gaze_dir).",
     )
-    
+
     # Eye-position jump rule
     parser.add_argument(
         "--enable-eye-jump-rule",
@@ -440,6 +449,20 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Velocity threshold (deg/s) for 'clear saccade' in jump rule (default: 50.0).",
     )
 
+
+def _add_postprocessing_arguments(parser: argparse.ArgumentParser) -> None:
+    # Gap-Filling
+    parser.add_argument(
+        "--gap-fill",
+        action="store_true",
+        help="Aktiviere zeitliches Gap-Filling (Interpolation pro Auge).",
+    )
+    parser.add_argument(
+        "--gap-fill-max-ms",
+        type=float,
+        default=75.0,
+        help="Maximale Luecken-Dauer in ms, die per Interpolation gefuellt wird (default: 75).",
+    )
     # GT-based Saccaden-Glättung
     parser.add_argument(
         "--post-smoothing-ms",
@@ -503,6 +526,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Ziel-Label fuer verworfene kurze Fixationen (default: Unclassified).",
     )
 
+
+def _add_evaluation_arguments(parser: argparse.ArgumentParser) -> None:
     # Evaluation
     parser.add_argument(
         "--evaluate",
@@ -515,6 +540,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Exclude samples whose presented stimulus name is 'Eyetracker Calibration' during evaluation.",
     )
 
+
+def _add_plotting_arguments(parser: argparse.ArgumentParser) -> None:
     # Plotting
     parser.add_argument(
         "--no-plot",
@@ -526,10 +553,6 @@ def build_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Velocity + GT-Event-Plot anzeigen (sonst nur Velocity).",
     )
-
-    return parser
-
-
 
 
 def main() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from ivt_filter.cli import build_arg_parser
+from ivt_filter.config.config_builder import ConfigBuilder
+
+
+CENTRAL_CLI_FLAGS = [
+    "--input",
+    "--output",
+    "--time-column",
+    "--time-unit",
+    "--window",
+    "--eye",
+    "--smoothing",
+    "--smooth-window-samples",
+    "--fixed-window-samples",
+    "--gap-fill",
+    "--gap-fill-max-ms",
+    "--velocity-method",
+    "--classify",
+    "--threshold",
+    "--enable-near-threshold-hybrid",
+    "--confident-switch-enabled",
+    "--post-smoothing-ms",
+    "--merge-close-fixations",
+    "--discard-short-fixations",
+    "--evaluate",
+    "--exclude-calibration",
+    "--no-plot",
+    "--with-events",
+]
+
+
+def _parser_flags() -> set[str]:
+    return {
+        option
+        for action in build_arg_parser()._actions
+        for option in action.option_strings
+    }
+
+
+def test_build_arg_parser_exposes_central_flags_snapshot() -> None:
+    flags = _parser_flags()
+
+    assert [flag for flag in CENTRAL_CLI_FLAGS if flag not in flags] == []
+
+
+def test_config_builder_accepts_cli_namespace_after_refactor() -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args(
+        [
+            "--input",
+            "input.tsv",
+            "--output",
+            "output.tsv",
+            "--time-column",
+            "time_us",
+            "--time-unit",
+            "us",
+            "--window",
+            "24",
+            "--eye",
+            "left",
+            "--smoothing",
+            "median",
+            "--smooth-window-samples",
+            "7",
+            "--smoothing-min-samples",
+            "2",
+            "--smoothing-expansion-radius",
+            "3",
+            "--fixed-window-samples",
+            "5",
+            "--fixed-window-edge-fallback",
+            "--allow-asymmetric-window",
+            "--use-fixed-dt",
+            "--sampling-rate-method",
+            "all_samples",
+            "--dt-calculation-method",
+            "mean",
+            "--no-fallback-valid-samples",
+            "--average-window-single-eye",
+            "--average-window-impute-neighbor",
+            "--average-fallback-single-eye",
+            "--gap-fill",
+            "--gap-fill-max-ms",
+            "42",
+            "--coordinate-rounding",
+            "halfup",
+            "--velocity-method",
+            "ray3d_gaze_dir",
+            "--tobii-eye-offset-interpolation",
+            "--classify",
+            "--threshold",
+            "31",
+            "--enable-invalid-window-neighbor-confirmation",
+            "--enable-hysteresis",
+            "--hysteresis-width",
+            "1.5",
+            "--enable-near-threshold-hybrid",
+            "--near-threshold-band",
+            "6",
+            "--near-threshold-band-lower",
+            "4",
+            "--near-threshold-band-upper",
+            "8",
+            "--near-threshold-strategy",
+            "replace",
+            "--near-threshold-confidence-margin",
+            "0.4",
+            "--near-threshold-require-same-side",
+            "--near-threshold-max-delta",
+            "3",
+            "--near-threshold-neighbor-check",
+            "--confident-switch-enabled",
+            "--confident-switch-margin-deg",
+            "5",
+            "--confident-switch-method",
+            "ray3d",
+            "--enable-eye-jump-rule",
+            "--eye-jump-threshold",
+            "12",
+            "--eye-jump-velocity-threshold",
+            "55",
+            "--post-smoothing-ms",
+            "10",
+            "--merge-close-fixations",
+            "--discard-short-fixations",
+        ]
+    )
+
+    pipeline_config = ConfigBuilder.build_pipeline_config(args)
+
+    assert pipeline_config.classify is True
+    assert pipeline_config.saccade_merge is not None
+    assert pipeline_config.fixation_post is not None
+    assert pipeline_config.velocity.window_length_ms == 24
+    assert pipeline_config.velocity.time_column == "time_us"
+    assert pipeline_config.velocity.time_unit == "us"
+    assert pipeline_config.velocity.eye_mode == "left"
+    assert pipeline_config.velocity.smoothing_mode == "median"
+    assert pipeline_config.velocity.smoothing_window_samples == 7
+    assert pipeline_config.velocity.smoothing_min_samples == 2
+    assert pipeline_config.velocity.smoothing_expansion_radius == 3
+    assert pipeline_config.velocity.fixed_window_edge_fallback is True
+    assert pipeline_config.velocity.allow_asymmetric_window is True
+    assert pipeline_config.velocity.use_fixed_dt is True
+    assert pipeline_config.velocity.sampling_rate_method == "all_samples"
+    assert pipeline_config.velocity.dt_calculation_method == "mean"
+    assert pipeline_config.velocity.use_fallback_valid_samples is False
+    assert pipeline_config.velocity.average_window_single_eye is True
+    assert pipeline_config.velocity.average_window_impute_neighbor is True
+    assert pipeline_config.velocity.average_fallback_single_eye is True
+    assert pipeline_config.velocity.gap_fill_enabled is True
+    assert pipeline_config.velocity.gap_fill_max_gap_ms == 42
+    assert pipeline_config.velocity.coordinate_rounding == "halfup"
+    assert pipeline_config.velocity.velocity_method == "ray3d_gaze_dir"
+    assert pipeline_config.velocity.tobii_eye_offset_interpolation is True
+    assert pipeline_config.classifier.velocity_threshold_deg_per_sec == 31
+    assert pipeline_config.classifier.enable_invalid_window_neighbor_confirmation is True
+    assert pipeline_config.classifier.enable_hysteresis is True
+    assert pipeline_config.classifier.hysteresis_width_deg_per_sec == 1.5
+    assert pipeline_config.classifier.enable_near_threshold_hybrid is True
+    assert pipeline_config.classifier.near_threshold_band == 6
+    assert pipeline_config.classifier.near_threshold_band_lower == 4
+    assert pipeline_config.classifier.near_threshold_band_upper == 8
+    assert pipeline_config.classifier.near_threshold_strategy == "replace"
+    assert pipeline_config.classifier.near_threshold_confidence_margin == 0.4
+    assert pipeline_config.classifier.near_threshold_require_same_side is True
+    assert pipeline_config.classifier.near_threshold_max_delta == 3
+    assert pipeline_config.classifier.near_threshold_neighbor_check is True
+    assert pipeline_config.classifier.enable_confident_switch is True
+    assert pipeline_config.classifier.confident_switch_margin_deg == 5
+    assert pipeline_config.classifier.confident_switch_method == "ray3d"
+    assert pipeline_config.classifier.enable_eye_jump_rule is True
+    assert pipeline_config.classifier.eye_jump_threshold_mm == 12
+    assert pipeline_config.classifier.eye_jump_velocity_threshold == 55


### PR DESCRIPTION
### Motivation
- Improve readability and maintainability by splitting the large `build_arg_parser()` into focused private helpers for logical argument groups. 
- Keep `build_arg_parser()` as the stable public entry point so external callers see no API surface change. 
- Add a smoke/snapshot test to detect accidental removal of central CLI flags. 
- Ensure `ConfigBuilder` still works with the parser-produced `argparse.Namespace` after the refactor.

### Description
- Moved argument registration out of the monolithic `build_arg_parser()` into private helper functions: `_add_io_arguments`, `_add_velocity_arguments`, `_add_window_arguments`, `_add_smoothing_arguments`, `_add_classifier_arguments`, `_add_refinement_arguments`, `_add_postprocessing_arguments`, `_add_evaluation_arguments`, and `_add_plotting_arguments`, and updated `build_arg_parser()` to call them (file: `ivt_filter/cli.py`).
- Preserved the original option names, choices, defaults and help text so the external CLI surface remains unchanged. 
- Added `tests/test_cli.py` containing a snapshot/smoke test that verifies a list of central flags is still exposed by the parser and a compatibility test that builds a `PipelineConfig` via `ConfigBuilder.build_pipeline_config(args)` from a parsed namespace. 
- Kept `ConfigBuilder` usage unchanged and verified it consumes the `argparse.Namespace` produced by the refactored parser.

